### PR TITLE
Getting an extra cas ticket that we could theoretically pass along to mediaflux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,8 @@ commands:
   run_mediaflux:
     steps:
       - run: echo "$DOCKERHUB_PASSWORD" | docker login --username $DOCKERHUB_USERNAME --password-stdin
-      - run: docker pull pulibraryrdss/mediaflux_dev:latest
-      - run: docker run -d --privileged --name mediaflux --publish 0.0.0.0:8888:80 --platform linux/amd64 --mac-address 02:42:ac:11:00:02 pulibraryrdss/mediaflux_dev:latest
+      - run: docker pull pulibraryrdss/mediaflux_dev:circle-ci
+      - run: docker run -d --privileged --name mediaflux --publish 0.0.0.0:8888:80  --mac-address 02:42:ac:11:00:02 pulibraryrdss/mediaflux_dev:circle-ci
 
   run_postgres:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,8 @@ commands:
   run_mediaflux:
     steps:
       - run: echo "$DOCKERHUB_PASSWORD" | docker login --username $DOCKERHUB_USERNAME --password-stdin
-      - run: docker pull pulibraryrdss/mediaflux_dev:circle-ci
-      - run: docker run -d --privileged --name mediaflux --publish 0.0.0.0:8888:80  --mac-address 02:42:ac:11:00:02 pulibraryrdss/mediaflux_dev:circle-ci
+      - run: docker pull pulibraryrdss/mediaflux_dev:latest
+      - run: docker run -d --privileged --name mediaflux --publish 0.0.0.0:8888:80 --platform linux/amd64 --mac-address 02:42:ac:11:00:02 pulibraryrdss/mediaflux_dev:latest
 
   run_postgres:
     steps:

--- a/app/channels/mediaflux_channel.rb
+++ b/app/channels/mediaflux_channel.rb
@@ -16,12 +16,8 @@ class MediafluxChannel < ApplicationCable::Channel
 
   private
 
-    def superuser
-      User.find_by(superuser: true)
-    end
-
     def session_token
-      superuser.mediaflux_session
+      SystemUser.mediaflux_session
     end
 
     def version_request

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,11 @@ class ApplicationController < ActionController::Base
     new_user_session_path
   end
 
+  def after_sign_in_path_for(_resource)
+    mediaflux_passthru_path
+    # "/users/#{@user.id}"
+  end
+
   def require_admin_user
     head :forbidden unless current_user&.eligible_sysadmin?
   end

--- a/app/controllers/users/mediaflux_callbacks_controller.rb
+++ b/app/controllers/users/mediaflux_callbacks_controller.rb
@@ -8,7 +8,7 @@ class Users::MediafluxCallbacksController < ApplicationController
     ticket = params[:ticket]
     uri = URI.parse(session[:cas_validation_url])
     token = "#{uri.query}#{ticket}"
-    current_user.medaiflux_login(token)
+    current_user.medaiflux_login(token, session)
     redirect_to(root_path)
   end
 end

--- a/app/controllers/users/mediaflux_callbacks_controller.rb
+++ b/app/controllers/users/mediaflux_callbacks_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class Users::MediafluxCallbacksController < ApplicationController
+  def passthru
+    redirect_to session[:cas_login_url], allow_other_host: true
+  end
+
+  def cas
+    ticket = params[:ticket]
+    msg =  "This is the URL that we could pass throug to mediaflux for them to validate the user who is logged in"
+    msg += "It is only valid once and for 60 seconds ticket: #{ticket} for url: #{session[:cas_validation_url]} "
+    msg += view_context.link_to("ticket validation", session[:cas_validation_url] + ticket)
+    flash[:notice] = msg
+    redirect_to(root_path)
+  end
+end

--- a/app/controllers/users/mediaflux_callbacks_controller.rb
+++ b/app/controllers/users/mediaflux_callbacks_controller.rb
@@ -6,10 +6,9 @@ class Users::MediafluxCallbacksController < ApplicationController
 
   def cas
     ticket = params[:ticket]
-    msg =  "This is the URL that we could pass throug to mediaflux for them to validate the user who is logged in"
-    msg += "It is only valid once and for 60 seconds ticket: #{ticket} for url: #{session[:cas_validation_url]} "
-    msg += view_context.link_to("ticket validation", session[:cas_validation_url] + ticket)
-    flash[:notice] = msg
+    uri = URI.parse(session[:cas_validation_url])
+    token = "#{uri.query}#{ticket}"
+    current_user.medaiflux_login(token)
     redirect_to(root_path)
   end
 end

--- a/app/controllers/users/mediaflux_callbacks_controller.rb
+++ b/app/controllers/users/mediaflux_callbacks_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Users::MediafluxCallbacksController < ApplicationController
   def passthru
+    session[:original_path] = params["path"]
     redirect_to session[:cas_login_url], allow_other_host: true
   end
 
@@ -9,6 +10,6 @@ class Users::MediafluxCallbacksController < ApplicationController
     uri = URI.parse(session[:cas_validation_url])
     token = "#{uri.query}#{ticket}"
     current_user.medaiflux_login(token, session)
-    redirect_to(root_path)
+    redirect_to(session["original_path"] || root_path)
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -4,6 +4,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     access_token = request.env["omniauth.auth"]
     @user = User.from_cas(access_token)
 
+    set_cas_session
+
     if @user.nil? && access_token&.provider == "cas"
       redirect_to help_path
       flash.notice = "You can not be signed in at this time."
@@ -14,4 +16,15 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
     end
   end
+
+  private
+
+    def set_cas_session
+      strategy = request.env["omniauth.strategy"]
+      if strategy.present?
+        service_url = strategy.append_params(mediaflux_extra_url, { url: request.referer })
+        session[:cas_login_url] = strategy.login_url(service_url)
+        session[:cas_validation_url] = strategy.service_validate_url(service_url, "")
+      end
+    end
 end

--- a/app/jobs/activate_project_job.rb
+++ b/app/jobs/activate_project_job.rb
@@ -26,10 +26,4 @@ class ActivateProjectJob < ApplicationJob
     }
     Honeybadger.notify(activation_failure_msg, context: honeybadger_context)
   end
-
-  private
-    def mediaflux_session
-      logon_request = Mediaflux::LogonRequest.new
-      logon_request.session_token
-    end
 end

--- a/app/models/mediaflux/logon_request.rb
+++ b/app/models/mediaflux/logon_request.rb
@@ -25,11 +25,12 @@ module Mediaflux
       mediaflux["api_password"]
     end
 
-    def initialize(domain: self.class.mediaflux_domain, user: self.class.mediaflux_user, password: self.class.mediaflux_password, identity_token: nil)
+    def initialize(domain: self.class.mediaflux_domain, user: self.class.mediaflux_user, password: self.class.mediaflux_password, identity_token: nil, token_type: nil)
       @domain = domain
       @user = user
       @password = password
       @identity_token = identity_token
+      @token_type = token_type
       super()
     end
 
@@ -67,7 +68,10 @@ module Mediaflux
               xml.user @user
               xml.password @password
             else
-              xml.token @identity_token
+              xml.token do
+                xml.parent.set_attribute("type", @token_type) if @token_type
+                xml.text(@identity_token)
+              end
             end
           end
         end

--- a/app/models/mediaflux/project_approve_request.rb
+++ b/app/models/mediaflux/project_approve_request.rb
@@ -4,8 +4,8 @@ module Mediaflux
   #
   # @example
   #  project = Project.first
-  #  project.save_in_mediaflux(session_id: User.first.mediaflux_session)
-  #  approve_req = Mediaflux::ProjectApproveRequest.new(session_token: User.first.mediaflux_session, project:)
+  #  project.save_in_mediaflux(session_id: SystemUser.mediaflux_session)
+  #  approve_req = Mediaflux::ProjectApproveRequest.new(session_token: SystemUser.mediaflux_session, project:)
   #  approve_req.resolve
   #
   class ProjectApproveRequest < Request

--- a/app/models/mediaflux/session_error.rb
+++ b/app/models/mediaflux/session_error.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module Mediaflux
+  # A error to be thrown when the session logon has an error
+  #   This error should not happen, but can happen if there is a bad password or a communication error
+  #
+  class SessionError < StandardError
+  end
+end

--- a/app/models/system_user.rb
+++ b/app/models/system_user.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class SystemUser
+  def self.mediaflux_session
+    Rails.cache.fetch("mediaflux_session", expires_in: 10.minutes) do
+      logon_request = Mediaflux::LogonRequest.new
+      if logon_request.error?
+        raise Mediaflux::SessionError, "System logon was invalid! #{logon_request.response_error}"
+      end
+      logon_request.session_token
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,11 +50,21 @@ class User < ApplicationRecord
     end
   end
 
+  def medaiflux_login(token)
+    logon_request = Mediaflux::LogonRequest.new(identity_token: token, token_type: "cas")
+    @mediaflux_session = logon_request.session_token
+    @cas_user = true
+  end
+
   def mediaflux_session
-    @mediaflux_session ||= begin
-                            logon_request = Mediaflux::LogonRequest.new
-                            logon_request.session_token
-                          end
+    if @mediaflux_session.nil? && @cas_user # the user's session has timed out.  Now what?
+      raise "Invalid mediflux session!"
+    elsif @mediaflux_session.nil? # utilize the service account
+      logon_request = Mediaflux::LogonRequest.new
+      @mediaflux_session = logon_request.session_token
+    end
+
+    @mediaflux_session
   end
 
   def terminate_mediaflux_session

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,7 +42,7 @@
         <div class="row">
           <div class="col">
           <% if flash[:notice]%>
-            <div class="alert alert-primary" role="alert" ><%= flash[:notice] %></div>
+            <div class="alert alert-primary" role="alert" ><%= flash[:notice]&.html_safe %></div>
           <% end %>
           <% if flash[:alert]%> 
             <div class="alert alert-warning" role="alert"><%= flash[:alert] %></div>

--- a/config/environments/qa.rb
+++ b/config/environments/qa.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = :info
+  config.log_level = :debug
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/initializers/health_monitor.rb
+++ b/config/initializers/health_monitor.rb
@@ -9,6 +9,9 @@ Rails.application.config.after_initialize do
     # Mediaflux check
     config.add_custom_provider(MediafluxStatus)
 
+    # allow the UI to load eve if mediaflux is down
+    config.providers.last.configuration.critical = false
+
     # Make this health check available at /health
     config.path = :health
 

--- a/config/initializers/health_monitor.rb
+++ b/config/initializers/health_monitor.rb
@@ -7,9 +7,9 @@ Rails.application.config.after_initialize do
       file_config.filename = "public/remove-from-nginx"
     end
     # Mediaflux check
-    # config.add_custom_provider(MediafluxStatus)
+    config.add_custom_provider(MediafluxStatus)
 
-    # allow the UI to load eve if mediaflux is down
+    # allow the UI to load evn if mediaflux is down
     config.providers.last.configuration.critical = false
 
     # Make this health check available at /health

--- a/config/initializers/health_monitor.rb
+++ b/config/initializers/health_monitor.rb
@@ -7,7 +7,7 @@ Rails.application.config.after_initialize do
       file_config.filename = "public/remove-from-nginx"
     end
     # Mediaflux check
-    config.add_custom_provider(MediafluxStatus)
+    # config.add_custom_provider(MediafluxStatus)
 
     # allow the UI to load eve if mediaflux is down
     config.providers.last.configuration.critical = false

--- a/config/mediaflux.yml
+++ b/config/mediaflux.yml
@@ -83,6 +83,15 @@ development:
   api_transport: <%= ENV["MEDIAFLUX_TRANSPORT"] || 'http' %>
   api_host: <%= ENV["MEDIAFLUX_HOST"] || '0.0.0.0' %>
   api_port: <%= ENV["MEDIAFLUX_PORT"] || '8888' %>
+  # api_hidden_root: '/cac01'
+  # api_root_to_clean: '/cac01/castest'
+  # api_root_ns: '/cac01/castest/tigerdataNS'
+  # api_root_collection_name: 'tigerdata'
+  # api_root_collection_namespace: '/cac01/castest'
+  # api_root_collection: 'path=/cac01/castest/tigerdata'
+  # api_transport: 'http'
+  # api_host: 'td-meta1.princeton.edu'
+  # api_port: '8080'
 
   # Alternate to development is an alternate location in docker
   api_alternate_hidden_root: '/td-alternate-001'

--- a/config/mediaflux.yml
+++ b/config/mediaflux.yml
@@ -83,16 +83,7 @@ development:
   api_transport: <%= ENV["MEDIAFLUX_TRANSPORT"] || 'http' %>
   api_host: <%= ENV["MEDIAFLUX_HOST"] || '0.0.0.0' %>
   api_port: <%= ENV["MEDIAFLUX_PORT"] || '8888' %>
-  # api_hidden_root: '/cac01'
-  # api_root_to_clean: '/cac01/castest'
-  # api_root_ns: '/cac01/castest/tigerdataNS'
-  # api_root_collection_name: 'tigerdata'
-  # api_root_collection_namespace: '/cac01/castest'
-  # api_root_collection: 'path=/cac01/castest/tigerdata'
-  # api_transport: 'http'
-  # api_host: 'td-meta1.princeton.edu'
-  # api_port: '8080'
-
+  
   # Alternate to development is an alternate location in docker
   api_alternate_hidden_root: '/td-alternate-001'
   api_alternate_root_ns:  '/td-alternate-001/tigerdataNS'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,4 +43,6 @@ Rails.application.routes.draw do
   end
 
   mount ActionCable.server => "/cable"
+  get "mediaflux_extra", to: "users/mediaflux_callbacks#cas", as: :mediaflux_extra
+  get "mediaflux_passthru", to: "users/mediaflux_callbacks#passthru", as: :mediaflux_passthru
 end

--- a/docs/aterm_101.md
+++ b/docs/aterm_101.md
@@ -410,7 +410,7 @@ For example:
   
   **Note 2** Our version of mediaflux in docker does not have this command. The xtoshell command does exist on td-meta1
   ```
-  session_id = User.first.mediaflux_session
+  session_id = SystemUser.mediaflux_session
   project = Project.first
   project_name = project.project_directory
   project_namespace = "#{project_name}NS"

--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -127,7 +127,7 @@ You can also utilize the TestAssetGenerator in the rails console to add assets t
 rails c
   user = User.first
   project = Project.last
-  project.save_in_mediaflux(session_id: user.mediaflux_session)
+  project.save_in_mediaflux(session_id: SystemUser.mediaflux_session)
   gen = TestAssetGenerator.new(project_id: project.id,user:, levels: 2, directory_per_level: 2,file_count_per_directory: 20)
   gen.generate
 ```
@@ -137,7 +137,7 @@ You can also utilize `Mediaflux::TestAssetCreateRequest` to generate some assets
 ```
 rails c
   parent_id = 1234 # collection id from mediaflux
-  gen = Mediaflux::TestAssetCreateRequest.new(session_token: User.first.mediaflux_session, parent_id:, count: 5, pattern: "test_asset_" )
+  gen = Mediaflux::TestAssetCreateRequest.new(session_token: SystemUser.mediaflux_session, parent_id:, count: 5, pattern: "test_asset_" )
   gen.resolve
 ```
 

--- a/docs/mediaflux_manual_installation.md
+++ b/docs/mediaflux_manual_installation.md
@@ -33,7 +33,7 @@ Per notes from Robert Knight, Mediaflux production is running Java 1.8.0.412.b08
 ### 4. get the installer
 ```unix
 $ sudo dnf install wget
-$ wget https://www.arcitecta.com/software/mf/4.16.071/mflux-dev_4.16.071_jvm_1.8.jar
+$ wget https://www.arcitecta.com/software/mf/4.16.082/mflux-dev_4.16.082_jvm_1.8.jar
 $ sudo java -jar mflux-dev_jvm_1.8.jar nogui
 -> accept
 -> /opt/mediaflux

--- a/docs/mediaflux_script_access.md
+++ b/docs/mediaflux_script_access.md
@@ -107,7 +107,7 @@ Because the user has has access to `server.log` we can even look at the log on t
 $ cat /usr/local/mediaflux/volatile/logs/filelist.1.log
 
 # output will include something along the lines of
-# [281 76649: Network Connection: http [port=8888]],version=4.16.071,filelist,30-Sep-2024
+# [281 76649: Network Connection: http [port=8888]],version=4.16.082,filelist,30-Sep-2024
 # 20:34:44.081:INFO:[user, id=157] system:scripter_user: File list for /path/to/collection
 ```
 

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -30,6 +30,7 @@ namespace :projects do
     raise "User id must be specified" if uid.blank?
     user = User.find_by(uid:)
     raise "User #{uid} not found" if user.nil?
+    user.mediaflux_from_session({}) # make sure we have the system login
     project_prefix = args[:prefix]
     raise "Project prefix must be specified" if project_prefix.nil?
     number = rand(10_000)

--- a/spec/channels/mediaflux_channel_spec.rb
+++ b/spec/channels/mediaflux_channel_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe MediafluxChannel, type: :channel, connect_to_mediaflux: true do
       identifier
     ]
   end
-  let(:superuser) { FactoryBot.create(:superuser) }
+  let(:superuser) { FactoryBot.create(:superuser, mediaflux_session: SystemUser.mediaflux_session) }
 
   before do
     superuser

--- a/spec/controllers/mediaflux_info_controller_spec.rb
+++ b/spec/controllers/mediaflux_info_controller_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe MediafluxInfoController, connect_to_mediaflux: true do
-  let(:user) { FactoryBot.create :user }
+  let(:user) { FactoryBot.create :user, mediaflux_session: SystemUser.mediaflux_session }
   let(:docker_response) { "{\"vendor\":\"Arcitecta Pty. Ltd.\",\"version\":\"4.16.071\"}" }
   let(:ansible_response) { "{\"vendor\":\"Arcitecta Pty. Ltd.\",\"version\":\"4.16.082\"}" }
 
@@ -24,7 +24,7 @@ RSpec.describe MediafluxInfoController, connect_to_mediaflux: true do
 
     Rails.configuration.mediaflux["api_password"] = "badpass"
 
-    expect { get :index }.to raise_error(Mediaflux::SessionExpired)
+    expect { get :index }.to raise_error(Mediaflux::SessionError)
 
     Rails.configuration.mediaflux["api_password"] = original_pass
   end

--- a/spec/controllers/mediaflux_info_controller_spec.rb
+++ b/spec/controllers/mediaflux_info_controller_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 RSpec.describe MediafluxInfoController, connect_to_mediaflux: true do
   let(:user) { FactoryBot.create :user }
   let(:docker_response) { "{\"vendor\":\"Arcitecta Pty. Ltd.\",\"version\":\"4.16.071\"}" }
-  let(:ansible_response) { "{\"vendor\":\"Arcitecta Pty. Ltd.\",\"version\":\"4.16.047\"}" }
+  let(:ansible_response) { "{\"vendor\":\"Arcitecta Pty. Ltd.\",\"version\":\"4.16.082\"}" }
 
   before do
     sign_in user

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Users::OmniauthCallbacksController do
     it "redirects to home page with notice" do
       allow(User).to receive(:from_cas) { project_sponsor }
       get :cas
-      expect(response).to redirect_to(root_path)
+      expect(response).to redirect_to(mediaflux_passthru_path)
     end
   end
 

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe WelcomeController do
   end
 
   context "when a user is logged in", connect_to_mediaflux: true do
-    let(:user) { FactoryBot.create :user }
+    let(:user) { FactoryBot.create :user, mediaflux_session: SystemUser.mediaflux_session }
     before do
       sign_in user
     end
@@ -84,7 +84,7 @@ RSpec.describe WelcomeController do
   end
 
   context "when a user is logged in", connect_to_mediaflux: true do
-    let(:user) { FactoryBot.create :user }
+    let(:user) { FactoryBot.create :user, mediaflux_session: SystemUser.mediaflux_session }
     before do
       sign_in user
     end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -14,6 +14,9 @@ FactoryBot.define do
     superuser { false }
     trainer { false }
 
+    trait :with_mediaflux_session do
+      mediaflux_session { SystemUser.mediaflux_session }
+    end
     ##
     # A user who is allowed to sponsor a project
     factory :project_sponsor do

--- a/spec/jobs/activate_project_job_spec.rb
+++ b/spec/jobs/activate_project_job_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe ActivateProjectJob, connect_to_mediaflux: true, type: :job do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:project_in_mediaflux) { FactoryBot.create(:project_with_doi, status: Project::APPROVED_STATUS) }
 
   before do

--- a/spec/jobs/file_inventory_cleanup_job_spec.rb
+++ b/spec/jobs/file_inventory_cleanup_job_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe FileInventoryCleanupJob, connect_to_mediaflux: true, type: :job do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:project_in_mediaflux) { FactoryBot.create(:project_with_doi) }
   let(:eight_days_ago) { Time.current.in_time_zone("America/New_York") - 8.days }
 

--- a/spec/jobs/file_inventory_job_spec.rb
+++ b/spec/jobs/file_inventory_job_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 RSpec.describe FileInventoryJob, connect_to_mediaflux: true do
   include ActiveJob::TestHelper
 
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:project_in_mediaflux) { FactoryBot.create(:project_with_doi) }
 
   before do

--- a/spec/models/mediaflux/accumulator_create_collection_request_spec.rb
+++ b/spec/models/mediaflux/accumulator_create_collection_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::AccumulatorCreateCollectionRequest, connect_to_mediaflux: true, type: :model do
   let(:mediaflux_url) { Mediaflux::Request.uri.to_s }
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:approved_project) { FactoryBot.create(:approved_project) }
   let(:mediaflux_response) { "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<response><reply type=\"result\"><result></result></reply></response>" }
 

--- a/spec/models/mediaflux/asset_create_request_spec.rb
+++ b/spec/models/mediaflux/asset_create_request_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Mediaflux::AssetCreateRequest, connect_to_mediaflux: true, type: 
   let(:session_token) { Mediaflux::LogonRequest.new.session_token }
   let(:root_ns) { Rails.configuration.mediaflux["api_root_collection_namespace"] }        # /td-test-001
   let(:parent_collection) { Rails.configuration.mediaflux["api_root_collection_name"] }   # tigerdata
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:approved_project) { FactoryBot.create(:approved_project) }
   let(:approved_project2) { FactoryBot.create(:approved_project) }
 
@@ -18,12 +18,11 @@ RSpec.describe Mediaflux::AssetCreateRequest, connect_to_mediaflux: true, type: 
   describe "#id" do
     it "creates a collection on the server" do
       Mediaflux::RootCollectionAsset.new(session_token: session_token, root_ns: root_ns, parent_collection: parent_collection).create
-      session_id = User.new.mediaflux_session
 
-      create_request = described_class.new(session_token: session_id, name: "testasset", namespace: Rails.configuration.mediaflux[:api_root_ns])
+      create_request = described_class.new(session_token: session_token, name: "testasset", namespace: Rails.configuration.mediaflux[:api_root_ns])
       expect(create_request.response_error).to be_blank
       expect(create_request.id).not_to be_blank
-      req = Mediaflux::AssetMetadataRequest.new(session_token: session_id, id: create_request.id)
+      req = Mediaflux::AssetMetadataRequest.new(session_token: session_token, id: create_request.id)
       metadata = req.metadata
       expect(metadata[:name]).to eq("testasset")
     end

--- a/spec/models/mediaflux/asset_destroy_request_spec.rb
+++ b/spec/models/mediaflux/asset_destroy_request_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe Mediaflux::AssetDestroyRequest, connect_to_mediaflux: true, type: :model do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:approved_project) { FactoryBot.create(:approved_project) }
   let(:mediaflux_response) { "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<response><reply type=\"result\"><result></result></reply></response>" }
 

--- a/spec/models/mediaflux/asset_exist_request_headers_spec.rb
+++ b/spec/models/mediaflux/asset_exist_request_headers_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe Mediaflux::AssetExistRequest, type: :model, connect_to_mediaflux: true do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:namespace_root) { Rails.configuration.mediaflux["api_root_collection_namespace"] }
 
   context "when we give a user to the class" do

--- a/spec/models/mediaflux/asset_metadata_request_spec.rb
+++ b/spec/models/mediaflux/asset_metadata_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::AssetMetadataRequest, connect_to_mediaflux: true, type: :model do
   let(:mediaflux_url) { "http://0.0.0.0:8888/__mflux_svc__" }
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:approved_project) { FactoryBot.create(:approved_project) }
   let(:mediaflux_response) { "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n" }
 
@@ -51,7 +51,7 @@ RSpec.describe Mediaflux::AssetMetadataRequest, connect_to_mediaflux: true, type
     end
 
     context "actual mediaflux connection" do
-      let(:current_user) { FactoryBot.create(:user, uid: "hc1234") }
+      let(:current_user) { FactoryBot.create(:user, uid: "hc1234", mediaflux_session: SystemUser.mediaflux_session) }
       let(:valid_project) { FactoryBot.create(:project_with_dynamic_directory, project_id: "10.34770/tbd") }
       let(:session_token) { current_user.mediaflux_session }
 

--- a/spec/models/mediaflux/collection_list_request_spec.rb
+++ b/spec/models/mediaflux/collection_list_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::CollectionListRequest, connect_to_mediaflux: true, type: :model do
   subject(:request) { described_class.new(session_token: user.mediaflux_session) }
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
 
   describe "#resolve" do
     it "retrieves the listing of collections within the default namespace" do

--- a/spec/models/mediaflux/iterator_destroy_request.rb
+++ b/spec/models/mediaflux/iterator_destroy_request.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::IteratorDestroyRequest, connect_to_mediaflux: true, type: :model do
   let(:mediaflux_url) { "http://0.0.0.0:8888/__mflux_svc__" }
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:approved_project) { FactoryBot.create(:approved_project) }
 
   describe "#result" do

--- a/spec/models/mediaflux/iterator_request_spec.rb
+++ b/spec/models/mediaflux/iterator_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::IteratorRequest, connect_to_mediaflux: true, type: :model do
   let(:mediaflux_url) { Mediaflux::Request.uri.to_s }
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:approved_project) { FactoryBot.create(:approved_project) }
 
   describe "#result" do

--- a/spec/models/mediaflux/logoff_request_spec.rb
+++ b/spec/models/mediaflux/logoff_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::LogoutRequest, connect_to_mediaflux: true, type: :model do
   subject(:request) { described_class.new(session_token: session_token) }
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:session_token) { user.mediaflux_session }
   let(:mediaflux_url) { Mediaflux::Request.uri.to_s }
 

--- a/spec/models/mediaflux/logon_request_spec.rb
+++ b/spec/models/mediaflux/logon_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::LogonRequest, connect_to_mediaflux: true, type: :model do
   subject(:request) { described_class.new }
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:session_token) { user.mediaflux_session }
   let(:mediaflux_url) { Mediaflux::Request.uri.to_s }
 

--- a/spec/models/mediaflux/namespace_create_request_spec.rb
+++ b/spec/models/mediaflux/namespace_create_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::NamespaceCreateRequest, connect_to_mediaflux: true, type: :model do
   # let(:mediaflux_url) { "http://0.0.0.0:8888/__mflux_svc__" }
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:mediaflux_response) { "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<response><reply type=\"result\"><result></result></reply></response>" }
 
   describe "#resolve" do

--- a/spec/models/mediaflux/namespace_describe_request_spec.rb
+++ b/spec/models/mediaflux/namespace_describe_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::NamespaceDescribeRequest, connect_to_mediaflux: true, type: :model do
   let(:mediaflux_url) { "http://0.0.0.0:8888/__mflux_svc__" }
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:mediaflux_response) { "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n" }
 
   describe "#metadata" do

--- a/spec/models/mediaflux/namespace_destroy_request_spec.rb
+++ b/spec/models/mediaflux/namespace_destroy_request_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 RSpec.describe Mediaflux::NamespaceDestroyRequest, type: :model, connect_to_mediaflux: true do
   let(:valid_project) { FactoryBot.create(:project_with_dynamic_directory, project_id: "10.34770/tbd") }
   let(:namespace) { "#{valid_project.project_directory_short}NS".strip.gsub(/[^A-Za-z\d]/, "-") }
-  let(:sponsor_user) { FactoryBot.create(:project_sponsor) }
+  let(:sponsor_user) { FactoryBot.create(:project_sponsor, mediaflux_session: SystemUser.mediaflux_session) }
   let(:session_id) { sponsor_user.mediaflux_session }
   context "when a namespace exists" do
     it "deletes a namespace and everything inside of it" do

--- a/spec/models/mediaflux/namespace_list_request_spec.rb
+++ b/spec/models/mediaflux/namespace_list_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::NamespaceListRequest, connect_to_mediaflux: true, type: :model do
   let(:mediaflux_url) { "http://0.0.0.0:8888/__mflux_svc__" }
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:mediaflux_response) { "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n" }
 
   describe "#metadata" do

--- a/spec/models/mediaflux/project_approve_request_spec.rb
+++ b/spec/models/mediaflux/project_approve_request_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe Mediaflux::ProjectApproveRequest, type: :model, connect_to_mediaflux: true do
-  let(:approver) { FactoryBot.create :sysadmin }
+  let(:approver) { FactoryBot.create :sysadmin, mediaflux_session: SystemUser.mediaflux_session }
   let(:session_id) { approver.mediaflux_session }
   let(:approved_project) do
     project = FactoryBot.create :approved_project

--- a/spec/models/mediaflux/project_create_request_spec.rb
+++ b/spec/models/mediaflux/project_create_request_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Mediaflux::ProjectCreateRequest, connect_to_mediaflux: true, type
   describe "#id" do
 
     it "sends the metadata to the server" do
-      data_user_ro = FactoryBot.create :user
-      data_user_rw = FactoryBot.create :user
+      data_user_ro = FactoryBot.create :user, mediaflux_session: SystemUser.mediaflux_session
+      data_user_rw = FactoryBot.create :user, mediaflux_session: SystemUser.mediaflux_session
       session_id =  data_user_ro.mediaflux_session
 
       created_on = Time.current.in_time_zone("America/New_York").iso8601

--- a/spec/models/mediaflux/project_update_request_spec.rb
+++ b/spec/models/mediaflux/project_update_request_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::ProjectUpdateRequest, connect_to_mediaflux: true, type: :model do
   let(:mediaflux_url) { "http://0.0.0.0:8888/__mflux_svc__" }
-  let(:user) { FactoryBot.create(:user) }
+  let(:session_token) { SystemUser.mediaflux_session }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: session_token) }
   let(:approved_project) { FactoryBot.create(:approved_project) }
   let(:mediaflux_response) { "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n" }
 
@@ -14,7 +15,7 @@ RSpec.describe Mediaflux::ProjectUpdateRequest, connect_to_mediaflux: true, type
     end
 
     it "passes the metadata values in the request" do
-      update_request = described_class.new(session_token: user.mediaflux_session, project: approved_project)
+      update_request = described_class.new(session_token: session_token, project: approved_project)
       update_request.resolve
       expect(update_request.error?).to be false
       expect(update_request.response_body).to include(mediaflux_response)
@@ -24,7 +25,7 @@ RSpec.describe Mediaflux::ProjectUpdateRequest, connect_to_mediaflux: true, type
       it "sends the metadata to the server", connect_to_mediaflux: true do
         data_user_ro = FactoryBot.create :user
         data_user_rw = FactoryBot.create :user
-        session_id = data_user_ro.mediaflux_session
+        session_id = session_token
         updated_on = Time.current.in_time_zone("America/New_York").iso8601.to_s
         created_on = Time.current.in_time_zone("America/New_York").advance(days: -1).iso8601.to_s
         project = FactoryBot.create :project, data_user_read_only: [data_user_ro.uid], data_user_read_write: [data_user_rw.uid], created_on: created_on,

--- a/spec/models/mediaflux/query_request_spec.rb
+++ b/spec/models/mediaflux/query_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::QueryRequest, connect_to_mediaflux: true, type: :model do
   let(:mediaflux_url) { Mediaflux::Request.uri.to_s }
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:approved_project) { FactoryBot.create(:approved_project) }
 
   describe "#result" do

--- a/spec/models/mediaflux/range_query_request_spec.rb
+++ b/spec/models/mediaflux/range_query_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::RangeQueryRequest, connect_to_mediaflux: true, type: :model do
   let(:mediaflux_url) { "http://0.0.0.0:8888/__mflux_svc__" }
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:approved_project) { FactoryBot.create(:approved_project) }
   let(:mediaflux_response) { "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<response><reply type=\"result\"><result></result></reply></response>" }
 

--- a/spec/models/mediaflux/schema_create_request_spec.rb
+++ b/spec/models/mediaflux/schema_create_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::SchemaCreateRequest, connect_to_mediaflux: true, type: :model do
   let(:mediaflux_url) { "http://0.0.0.0:8888/__mflux_svc__" }
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:approved_project) { FactoryBot.create(:approved_project) }
   let(:mediaflux_response) { "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<response><reply type=\"result\"><result></result></reply></response>" }
 

--- a/spec/models/mediaflux/schema_fields_create_request_spec.rb
+++ b/spec/models/mediaflux/schema_fields_create_request_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe Mediaflux::SchemaFieldsCreateRequest, type: :model, connect_to_mediaflux: true do
-  let(:user) { FactoryBot.create :user }
+  let(:user) { FactoryBot.create :user, mediaflux_session: SystemUser.mediaflux_session }
   let(:required_indexed_field) { { name: "code", type: "string", index: true, "min-occurs" => 1, "max-occurs" => 1, label: "desc" } }
   let(:required_not_indexed_field) { { name: "title", type: "string", index: false, "min-occurs" => 1, "max-occurs" => 1, label: "desc" } }
   let(:optional_field) do

--- a/spec/models/mediaflux/service_execute_request_spec.rb
+++ b/spec/models/mediaflux/service_execute_request_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 RSpec.describe Mediaflux::ServiceExecuteRequest, connect_to_mediaflux: true, type: :model do
   subject(:request) { described_class.new(session_token: user.mediaflux_session, service_name: "asset.namespace.list") }
 
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:approved_project) { FactoryBot.create(:approved_project) }
   let(:session_token) { "test-session-token" }
   let(:identity_token) { "test-identity-token" }

--- a/spec/models/mediaflux/store_list_request_spec.rb
+++ b/spec/models/mediaflux/store_list_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::StoreListRequest, connect_to_mediaflux: true, type: :model do
   let(:mediaflux_url) { Mediaflux::Request.uri.to_s }
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:approved_project) { FactoryBot.create(:approved_project) }
   let(:mediaflux_response) { "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<response><reply type=\"result\"><result></result></reply></response>" }
   # Docker and Ansible responses are the same, but may be different in the future

--- a/spec/models/mediaflux/test_asset_create_request_spec.rb
+++ b/spec/models/mediaflux/test_asset_create_request_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe Mediaflux::TestAssetCreateRequest, connect_to_mediaflux: true, type: :model do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:approved_project) { FactoryBot.create(:approved_project) }
   let(:mediaflux_response) { "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<response><reply type=\"result\"><result></result></reply></response>" }
   # let(:mediaflux_url) { "http://0.0.0.0:8888/__mflux_svc__" }

--- a/spec/models/mediaflux/time_spec.rb
+++ b/spec/models/mediaflux/time_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::Time do
     let(:project) { FactoryBot.build :project_with_doi }
-    let(:current_user) { FactoryBot.create(:user, uid: "jh1234") }
+    let(:current_user) { FactoryBot.create(:user, uid: "jh1234", mediaflux_session: SystemUser.mediaflux_session) }
     let(:docker_response) { "Etc/UTC" }
     let(:ansible_response) { "America/Chicago" }
     subject(:instance) { described_class.new }

--- a/spec/models/mediaflux/token_create_request_spec.rb
+++ b/spec/models/mediaflux/token_create_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::TokenCreateRequest, connect_to_mediaflux: true, type: :model do
   subject(:request) { described_class.new(session_token: session_token, domain: Mediaflux::LogonRequest.mediaflux_domain, user: Mediaflux::LogonRequest.mediaflux_user) }
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:session_token) { user.mediaflux_session }
   let(:mediaflux_url) { Mediaflux::Request.uri.to_s }
 

--- a/spec/models/mediaflux/version_request_spec.rb
+++ b/spec/models/mediaflux/version_request_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 RSpec.describe Mediaflux::VersionRequest, connect_to_mediaflux: true, type: :model do
   subject(:request) { described_class.new(session_token: session_token) }
   let(:session_token) { user.mediaflux_session }
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:expected_mflux_version) { "4.16" }
 
   describe "#resolve" do

--- a/spec/models/project_accumulator_spec.rb
+++ b/spec/models/project_accumulator_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe ProjectAccumulator, connect_to_mediaflux: true do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:session_id) { user.mediaflux_session }
   let(:project_in_mediaflux) { FactoryBot.create(:project_with_doi, status: Project::APPROVED_STATUS) }
 

--- a/spec/models/project_mediaflux_spec.rb
+++ b/spec/models/project_mediaflux_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 RSpec.describe ProjectMediaflux, type: :model do
   let(:collection_metadata) { { id: "abc", name: "test", path: "/td-demo-001/rc/test-ns/test", description: "description", namespace: "/td-demo-001/rc/test-ns" } }
   let(:project) { FactoryBot.build :project_with_doi }
-  let(:current_user) { FactoryBot.create(:user, uid: "jh1234") }
+  let(:current_user) { FactoryBot.create(:user, uid: "jh1234", mediaflux_session: SystemUser.mediaflux_session) }
 
   describe "#create!", connect_to_mediaflux: true do
     context "Using test data" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe Project, type: :model, connect_to_mediaflux: true do
-  let(:user) { FactoryBot.create(:user, uid: "abc123") }
+  let(:user) { FactoryBot.create(:user, uid: "abc123", mediaflux_session: SystemUser.mediaflux_session) }
 
   describe "#sponsored_projects" do
     let(:sponsor) { FactoryBot.create(:user, uid: "hc1234") }
@@ -166,7 +166,7 @@ RSpec.describe Project, type: :model, connect_to_mediaflux: true do
   end
 
   describe "#file_list" do
-    let(:manager) { FactoryBot.create(:user, uid: "hc1234") }
+    let(:manager) { FactoryBot.create(:user, uid: "hc1234", mediaflux_session: SystemUser.mediaflux_session) }
     let(:project) do
       project = FactoryBot.create(:approved_project, title: "project 111", data_manager: manager.uid)
       project.mediaflux_id = nil
@@ -209,7 +209,7 @@ RSpec.describe Project, type: :model, connect_to_mediaflux: true do
   end
 
   describe "#save_in_mediaflux" do
-    let(:user) { FactoryBot.create(:user) }
+    let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
     let(:project) { FactoryBot.create(:project_with_doi) }
     it "calls ProjectMediaflux to create the project and save the id" do
       expect(project.mediaflux_id).to be nil
@@ -282,7 +282,7 @@ RSpec.describe Project, type: :model, connect_to_mediaflux: true do
 
   describe "#create!" do
     let(:datacite_stub) { instance_double(PULDatacite, draft_doi: "aaabbb123") }
-    let(:current_user) { FactoryBot.create(:user) }
+    let(:current_user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
     let(:project) { FactoryBot.create(:project) }
 
     before do
@@ -331,7 +331,7 @@ RSpec.describe Project, type: :model, connect_to_mediaflux: true do
 
   describe "#approve!" do
     let(:datacite_stub) { instance_double(PULDatacite, draft_doi: "aaabbb123") }
-    let(:current_user) { FactoryBot.create(:user) }
+    let(:current_user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
     let(:project) { FactoryBot.create(:project) }
 
     before do
@@ -370,7 +370,7 @@ RSpec.describe Project, type: :model, connect_to_mediaflux: true do
 
   describe "#activate!" do
   let(:project) { FactoryBot.create(:project_with_dynamic_directory, project_id: "10.34770/tbd")}
-  let(:current_user) { FactoryBot.create(:user) }
+  let(:current_user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
   let(:project_metadata) {project.metadata_model}
   after do
     Mediaflux::AssetDestroyRequest.new(session_token: current_user.mediaflux_session, collection: project.mediaflux_id, members: true).resolve

--- a/spec/models/system_user_spec.rb
+++ b/spec/models/system_user_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe SystemUser, type: :model do
+  let(:mediaflux_logon) { instance_double Mediaflux::LogonRequest, error?: false, session_token: "111222333" }
+  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
+  before do
+    allow(Mediaflux::LogonRequest).to receive(:new).and_return(mediaflux_logon)
+    allow(Rails).to receive(:cache).and_return(memory_store)
+    Rails.cache.clear
+  end
+
+  describe "#mediaflux_session" do
+    it "calls out to Mediaflux to login" do
+      expect(SystemUser.mediaflux_session).to eq("111222333")
+      # calling a second time to text the cache
+      expect(SystemUser.mediaflux_session).to eq("111222333")
+      expect(mediaflux_logon).to have_received(:session_token).once
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -214,4 +214,20 @@ RSpec.describe User, type: :model do
       expect(user).to be_eligible_sysadmin
     end
   end
+
+  describe "#mediaflux_from_session" do
+    let(:user) { described_class.new }
+    before do
+      allow(SystemUser).to receive(:mediaflux_session).and_return("111system")
+    end
+    it "loads the mediaflux session from the system user" do
+      expect(user.mediaflux_from_session({})).to eq("111system")
+      expect(user.mediaflux_session).to eq("111system")
+    end
+
+    it "loads the mediaflux session from the session when present" do
+      expect(user.mediaflux_from_session({ mediaflux_session: "222session" })).to eq("222session")
+      expect(user.mediaflux_session).to eq("222session")
+    end
+  end
 end

--- a/spec/requests/mediaflux_info_spec.rb
+++ b/spec/requests/mediaflux_info_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe "/mediaflux_info", connect_to_mediaflux: true, type: :request do
     context "logged in user" do
       let(:user) { FactoryBot.create(:user, uid: "pul123") }
       let(:mediaflux_url) { Mediaflux::Request.uri.to_s }
-      let(:docker_response) { "4.16.071" }
-      let(:ansible_response) { "4.16.047" }
+      let(:docker_response) { "4.16.082" }
+      let(:ansible_response) { "4.16.071" }
 
       before do
         sign_in user

--- a/spec/requests/mediaflux_info_spec.rb
+++ b/spec/requests/mediaflux_info_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "/mediaflux_info", connect_to_mediaflux: true, type: :request do
     end
 
     context "logged in user" do
-      let(:user) { FactoryBot.create(:user, uid: "pul123") }
+      let(:user) { FactoryBot.create(:user, uid: "pul123", mediaflux_session: SystemUser.mediaflux_session) }
       let(:mediaflux_url) { Mediaflux::Request.uri.to_s }
       let(:docker_response) { "4.16.082" }
       let(:ansible_response) { "4.16.071" }

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "/projects", connect_to_mediaflux: true, type: :request do
     end
 
     context "when the client is authenticated" do
-      let(:user) { FactoryBot.create(:user, uid: "pul123") }
+      let(:user) { FactoryBot.create(:user, uid: "pul123", mediaflux_session: SystemUser.mediaflux_session) }
       let(:title) { "a title" }
       let(:project_directory) { "/test-project" }
 

--- a/spec/services/test_project_generator_spec.rb
+++ b/spec/services/test_project_generator_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe TestProjectGenerator, connect_to_mediaflux: true do
   let(:subject) { described_class.new(user:, number: 1, project_prefix: 'test-project') }
-  let(:user) { FactoryBot.create :user }
+  let(:user) { FactoryBot.create :user, mediaflux_session: SystemUser.mediaflux_session}
 
   describe "#generate" do
     it "creates a project in mediaflux" do

--- a/spec/support/connect_to_mediaflux.rb
+++ b/spec/support/connect_to_mediaflux.rb
@@ -4,12 +4,15 @@ Rails.application.load_tasks
 
 def reset_mediaflux_root
   # Clean out the namespace before running tests to avoid collisions
-  user = User.new
+  user = SystemUser
   destroy_root_namespace(user)
 
   # then create it and the project root collection and namespace so it exists for any tests
   create_test_root_namespace(user)
   ProjectMediaflux.create_root_tree(session_id: user.mediaflux_session)
+
+  # Clear the login cache
+  Rails.cache.clear
 end
 
 def destroy_root_namespace(user)

--- a/spec/system/mediaflux_info_spec.rb
+++ b/spec/system/mediaflux_info_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe "mediaflux_info", type: :system, js: true, connect_to_mediaflux: true do
-  let(:current_user) { FactoryBot.create(:user, uid: "pul123") }
+  let(:current_user) { FactoryBot.create(:user, uid: "pul123", mediaflux_session: SystemUser.mediaflux_session) }
   let(:mflux_port) { Rails.configuration.mediaflux["api_port"] }
 
   it "shows the mediaflux version" do

--- a/spec/system/mediaflux_session_spec.rb
+++ b/spec/system/mediaflux_session_spec.rb
@@ -8,20 +8,25 @@ RSpec.describe "Mediaflux Sessions", type: :system do
   let(:sponsor_user) { FactoryBot.create(:project_sponsor, uid: "pul123") }
   let(:project) { FactoryBot.create(:project, mediaflux_id: "abc123") }
 
-  before do
-    sign_in sponsor_user
-  end
+  context "user is signed in" do
+    let(:original_session) { SystemUser.mediaflux_session }
+    let(:new_session) { SystemUser.mediaflux_session }
+    let(:mediaflux_logon) { instance_double Mediaflux::LogonRequest, error?: false, session_token: new_session }
 
-  it "reconnects to mediaflux after the session ends", connect_to_mediaflux: true do
-    original_session = sponsor_user.mediaflux_session
+    before do
+      sign_in sponsor_user
+      allow_any_instance_of(ActionDispatch::Request::Session).to receive(:[]).and_call_original
+      allow_any_instance_of(ActionDispatch::Request::Session).to receive(:[]).with(:mediaflux_session).and_return(original_session)
+      allow_any_instance_of(ActionDispatch::Request::Session).to receive(:[]).with(:active_web_user).and_return(true)
+    end
 
-    # logout the session so we get an error and need to reset the session
-    Mediaflux::LogoutRequest.new(session_token: original_session).resolve
+    it "connects to mediaflux once", connect_to_mediaflux: true do
+      visit root_path
 
-    expect { visit project_path(project) }.not_to raise_error
-    expect(page).to have_content("Total Files: 0")
+      expect { visit project_path(project) }.not_to raise_error
+      expect(page).to have_content("Total Files: 0")
 
-    # a new session got automatically connected for the user in the application controller
-    expect(sponsor_user.mediaflux_session).not_to eq(original_session)
+      expect(sponsor_user.mediaflux_session).to eq(original_session)
+    end
   end
 end

--- a/spec/system/project_details_spec.rb
+++ b/spec/system/project_details_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe "Project Details Page", type: :system, connect_to_mediaflux: true, js: true do
-  let(:sponsor_user) { FactoryBot.create(:project_sponsor, uid: "pul123") }
-  let(:sysadmin_user) { FactoryBot.create(:sysadmin, uid: "puladmin") }
-  let(:data_manager) { FactoryBot.create(:user, uid: "pul987") }
+  let(:sponsor_user) { FactoryBot.create(:project_sponsor, uid: "pul123", mediaflux_session: SystemUser.mediaflux_session) }
+  let(:sysadmin_user) { FactoryBot.create(:sysadmin, uid: "puladmin", mediaflux_session: SystemUser.mediaflux_session) }
+  let(:data_manager) { FactoryBot.create(:user, uid: "pul987", mediaflux_session: SystemUser.mediaflux_session) }
   let(:read_only) { FactoryBot.create :user }
   let(:read_write) { FactoryBot.create :user }
   let(:pending_text) do

--- a/spec/system/project_roles_spec.rb
+++ b/spec/system/project_roles_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 RSpec.describe "Project Edit Page Roles Validation", type: :system, connect_to_mediaflux: true, js: true do
-  let(:sponsor_user) { FactoryBot.create(:project_sponsor, uid: "pul123") }
-  let(:data_manager) { FactoryBot.create(:data_manager, uid: "pul987") }
-  let(:system_admin) { FactoryBot.create(:sysadmin, uid: "pul777") }
-  let(:superuser) { FactoryBot.create(:superuser, uid: "pul999") }
+  let(:sponsor_user) { FactoryBot.create(:project_sponsor, uid: "pul123", mediaflux_session: SystemUser.mediaflux_session) }
+  let(:data_manager) { FactoryBot.create(:data_manager, uid: "pul987", mediaflux_session: SystemUser.mediaflux_session) }
+  let(:system_admin) { FactoryBot.create(:sysadmin, uid: "pul777", mediaflux_session: SystemUser.mediaflux_session) }
+  let(:superuser) { FactoryBot.create(:superuser, uid: "pul999", mediaflux_session: SystemUser.mediaflux_session) }
   let(:read_only) { FactoryBot.create :user }
   let(:read_write) { FactoryBot.create :user }
   before do
@@ -81,7 +81,7 @@ RSpec.describe "Project Edit Page Roles Validation", type: :system, connect_to_m
   end
 
   context "Data Sponsors and superusers are the only ones who can request a new project" do
-    let(:superuser) { FactoryBot.create(:superuser) }
+    let(:superuser) { FactoryBot.create(:superuser, mediaflux_session: SystemUser.mediaflux_session) }
     it "allows Data Sponsors to request a new project" do
       sign_in sponsor_user
       visit "/"

--- a/spec/system/project_spec.rb
+++ b/spec/system/project_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe "Project Page", connect_to_mediaflux: true, type: :system  do
-  let(:sponsor_user) { FactoryBot.create(:project_sponsor, uid: "pul123") }
-  let(:sysadmin_user) { FactoryBot.create(:sysadmin, uid: "puladmin") }
-  let!(:data_manager) { FactoryBot.create(:data_manager, uid: "pul987") }
+  let(:sponsor_user) { FactoryBot.create(:project_sponsor, uid: "pul123", mediaflux_session: SystemUser.mediaflux_session) }
+  let(:sysadmin_user) { FactoryBot.create(:sysadmin, uid: "puladmin", mediaflux_session: SystemUser.mediaflux_session) }
+  let!(:data_manager) { FactoryBot.create(:data_manager, uid: "pul987", mediaflux_session: SystemUser.mediaflux_session) }
   let(:read_only) { FactoryBot.create :user }
   let(:read_write) { FactoryBot.create :user }
   let(:pending_text) do

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe "WelcomeController", connect_to_mediaflux: true, js: true do
     let(:other_user) { FactoryBot.create(:user, uid: "zz123") }
     let(:no_projects_user) { FactoryBot.create(:user, uid: "qw999") }
     let(:no_projects_sponsor) { FactoryBot.create(:project_sponsor, uid: "gg717") }
-    let(:docker_response) { "Mediaflux: 4.16.071" }
-    let(:ansible_response) { "Mediaflux: 4.16.047" }
+    let(:docker_response) { "Mediaflux: 4.16.082" }
+    let(:ansible_response) { "Mediaflux: 4.16.071" }
 
     before do
       FactoryBot.create(:project, data_sponsor: current_user.uid, data_manager: other_user.uid, title: "project 111")

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "WelcomeController", connect_to_mediaflux: true, js: true do
   end
 
   context "authenticated user" do
-    let(:current_user) { FactoryBot.create(:user, uid: "pul123") }
+    let(:current_user) { FactoryBot.create(:user, uid: "pul123", mediaflux_session: SystemUser.mediaflux_session) }
     let(:other_user) { FactoryBot.create(:user, uid: "zz123") }
     let(:no_projects_user) { FactoryBot.create(:user, uid: "qw999") }
     let(:no_projects_sponsor) { FactoryBot.create(:project_sponsor, uid: "gg717") }


### PR DESCRIPTION
refs #868 

When the user logs in this PR runs a connection to mediaflux and tries to login with a cas ticket

It introduces the concept of SystemUser - which is our old configured user, and active_web_user, which is a user in the browser.  We need to keep track becuase if the user is utilizing a cas token, when the mediaflux session expires we need to get another cas token.

The information on if the user is and `active_web_user` or not is kept in the session along with the mediaflux session token/id.


Most of the additional changes in this PR are to make the test all utilize the SystemUser for their Mediaflux token/id.