### PR TITLE
Adding a caveat to the contents preview page

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -154,6 +154,18 @@
 }
 
 #content{
+
+  #file-list {
+    width:90%;
+    border: 1px solid gray;
+  }
+
+  #file-list > tbody > tr > th {
+    background-color: #dddcdc;
+  }
+  label{
+    padding-bottom: .5em;
+  }
   dt {
     float: left;
     min-width: calc(25% + 5em);
@@ -163,6 +175,7 @@
     margin-left: 1em;
     clear: both
   }
+
   dd{
     margin-bottom: .5rem;
     margin-left: 0;
@@ -175,6 +188,18 @@
     &__summary {
       display: inline;
     }
+  }
+
+  .numeric_column {
+    text-align: right;
+  }
+
+  .visible-row {
+    visibility: unset;
+  }
+
+  .invisible-row {
+    visibility: collapse;
   }
 }
 

--- a/app/views/projects/contents.html.erb
+++ b/app/views/projects/contents.html.erb
@@ -1,25 +1,3 @@
-<style>
-  #file-list {
-    width:90%;
-    border: 1px solid gray;
-  }
-
-  #file-list > tbody > tr > th {
-    background-color: #dddcdc;
-  }
-
-  .numeric_column {
-    text-align: right;
-  }
-
-  .visible-row {
-    visibility: unset;
-  }
-
-  .invisible-row {
-    visibility: collapse;
-  }
-</style>
 <content id= "content">
   <h1>Project Contents</h1>
   <h2>Contents Summary</h2>
@@ -35,6 +13,8 @@
     <section class="container-fluid px-1 mx-2 my-4 project-contents__preview">
       <div>
         <h2>Contents Preview</h2>
+        <p class="text-muted"> Please note that the contents preview feature is still under development and currently only displays world-readable files (not those with more limited permissions).
+        You can still find all of the contents you have access to through the project's mount point.</p>
         <table id="file-list">
           <tr>
             <th>Path</th>

--- a/spec/system/project_show_spec.rb
+++ b/spec/system/project_show_spec.rb
@@ -175,6 +175,17 @@ RSpec.describe "Project Page", type: :system, connect_to_mediaflux: true, js: tr
         expect(page).to have_content("Project Details: #{project.title}")
       end
 
+      it "displays the caveat message" do
+        # sign in and be able to view the file count for the collection
+        sign_in sponsor_user
+        visit "/projects/#{project.id}"
+        expect(page).to have_selector(:link_or_button, "Review Contents")
+        click_on("Review Contents")
+
+        # Caveat message is displayed
+        expect(page).to have_content("Please note that the contents preview feature is still under development and currently only displays world-readable files")
+      end
+
       it "displays the file list" do
         # sign in and be able to view the file count for the collection
         sign_in sponsor_user


### PR DESCRIPTION
closes #945 

![Screenshot 2024-09-24 at 12 07 57 PM](https://github.com/user-attachments/assets/14337383-4e6e-4b49-9782-c427bfbe7aea)
