### PR TITLE
Remove trailing project status from title to allow user to focus on status banner

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -95,12 +95,7 @@ class Project < ApplicationRecord
   end
 
   def title
-    trailer = if in_mediaflux?
-                ""
-              else
-                " (#{::Project::PENDING_STATUS})"
-              end
-    self.metadata_model.title + trailer
+    self.metadata_model.title
   end
 
   def departments

--- a/spec/system/project_roles_spec.rb
+++ b/spec/system/project_roles_spec.rb
@@ -71,8 +71,6 @@ RSpec.describe "Project Edit Page Roles Validation", type: :system, connect_to_m
     expect(page).to have_content("Welcome")
     click_on("My test project")
     expect(page).to have_content("This project has not been saved to Mediaflux")
-    expect(page).to have_content("My test project (pending)")
-    expect(page).to have_content("My test project (#{::Project::PENDING_STATUS})")
     expect(page).to have_content(read_only.given_name)
     expect(page).to have_content(read_only.display_name)
     expect(page).to have_content(read_only.family_name)

--- a/spec/system/project_show_spec.rb
+++ b/spec/system/project_show_spec.rb
@@ -244,7 +244,6 @@ RSpec.describe "Project Page", type: :system, connect_to_mediaflux: true, js: tr
       it "shows the sysadmin buttons for a pending project" do
         sign_in sysadmin_user
         visit "/projects/#{project_not_in_mediaflux.id}"
-        expect(page).to have_content "#{project_not_in_mediaflux.metadata_model.title} (#{::Project::PENDING_STATUS})"
         expect(page).to have_content "This project has not been saved to Mediaflux"
         expect(page).to have_content pending_text
         expect(page).to have_selector(:link_or_button, "Approve Project")

--- a/spec/system/project_spec.rb
+++ b/spec/system/project_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe "Project Page", connect_to_mediaflux: true, type: :system  do
       it "Shows the not yet approved (pending) project" do
         sign_in sponsor_user
         visit "/projects/#{project_not_in_mediaflux.id}"
-        expect(page).to have_content "(#{::Project::PENDING_STATUS})"
         expect(page).to have_content pending_text
       end
     end
@@ -77,7 +76,6 @@ RSpec.describe "Project Page", connect_to_mediaflux: true, type: :system  do
       it "shows none when the data user is empty" do
         sign_in data_manager
         visit "/projects/#{project_not_in_mediaflux.id}"
-        expect(page).to have_content "project 123 (#{::Project::PENDING_STATUS})"
         expect(page).to have_content "This project has not been saved to Mediaflux"
         expect(page).to have_content pending_text
         expect(page).not_to have_button "Approve Project"
@@ -403,7 +401,6 @@ RSpec.describe "Project Page", connect_to_mediaflux: true, type: :system  do
       sign_in sponsor_user
       visit "/projects"
       expect(page).to have_content(project_not_in_mediaflux.title)
-      expect(page).to have_content("(#{::Project::PENDING_STATUS})")
     end
   end
 


### PR DESCRIPTION
ref #1008 