### PR TITLE
Making the numbers make sense on any page in the projects lists

### DIFF
--- a/app/javascript/entrypoints/pulDataTables.js
+++ b/app/javascript/entrypoints/pulDataTables.js
@@ -12,7 +12,7 @@ export function setupTable(tableId) {
     searching: false,
     // use example spanish translation to know what to change in language https://cdn.datatables.net/plug-ins/2.1.8/i18n/es-ES.json
     language: {
-      info: '_END_ out of _TOTAL_ shown',
+      info: '_START_ - _END_ out of _TOTAL_ shown',
       paginate: { next: '>', previous: '<' },
     },
   };


### PR DESCRIPTION
Previously on page 2 it showed:

![Screenshot 2024-12-04 at 12 30 00 PM](https://github.com/user-attachments/assets/6adecc2c-2281-4348-bd0d-940090c63566)

With the PR it shows:
![Screenshot 2024-12-04 at 12 29 23 PM](https://github.com/user-attachments/assets/9c01175a-1696-469b-bf19-e418037e2a2b)

It is not what was asked for by the UX team, but we do not have a great way of getting the number of items displayed.  We may have to add our own page info section and hide the page info section from DataTable to get it just as designed.
