### PR TITLE
Added sort order for project dashboards

### DIFF
--- a/app/presenters/project_dashboard_presenter.rb
+++ b/app/presenters/project_dashboard_presenter.rb
@@ -31,6 +31,10 @@ class ProjectDashboardPresenter < ProjectShowPresenter
     end
   end
 
+  def updated_at
+    project.updated_at
+  end 
+
   def role(user)
     if data_sponsor == user.uid
       "Sponsor"

--- a/app/views/welcome/_admin_listing.html.erb
+++ b/app/views/welcome/_admin_listing.html.erb
@@ -3,7 +3,7 @@
    <div class="section">
       <h2>Pending Projects</h2>
       <% if !@pending_projects.empty? %>
-         <%= render partial: "projects_listing", locals: { projects: @pending_projects,  table_id: "projects-listing-pending" } %>
+         <%= render partial: "projects_listing", locals: { projects: @pending_projects.sort_by(&:updated_at),  table_id: "projects-listing-pending" } %>
       <% else %>
          <p> (none) </p>
       <% end %>
@@ -11,7 +11,7 @@
       <div class="section">
       <h2>Recently Approved Projects</h2>
       <% if !@approved_projects.empty? %>
-       <%= render partial: "projects_listing", locals: { projects: @approved_projects,  table_id: "projects-listing-approved"} %>
+       <%= render partial: "projects_listing", locals: { projects: @approved_projects.sort_by(&:updated_at).reverse,  table_id: "projects-listing-approved"} %>
       <% else %>
         <p> (none) </p>
       <% end %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -19,7 +19,7 @@
     <button id="dash-admin" class="tab-nav"> Administration </button>
     </div>
         <% if @dash_session == "project"%>
-          <%= render partial: "projects_listing", locals: { projects: @dashboard_projects,  table_id: "projects-listing" } %>
+          <%= render partial: "projects_listing", locals: { projects: @dashboard_projects.sort_by(&:updated_at).reverse,  table_id: "projects-listing" } %>
         <% elsif @dash_session == "activity" %>
           <%= render partial: "recent_activity" %>
         <% elsif @dash_session == "admin" %>

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -113,18 +113,18 @@ RSpec.describe "WelcomeController", connect_to_mediaflux: true, js: true do
       end
 
       it "paginates the projects; 8 per page" do
-        projects = (1..16).map { FactoryBot.create(:project, data_sponsor: other_user.uid, data_manager: other_user.uid, data_user_read_only: [current_user.uid]) }
+        projects = (1..17).map { FactoryBot.create(:project, data_sponsor: other_user.uid, data_manager: other_user.uid, data_user_read_only: [current_user.uid]) }
         sign_in current_user
         visit "/"
-        expect(page).to have_content("8 out of 17 shown")
+        expect(page).to have_content("8 out of 18 shown")
         find("a.paginate_button", text: 2).click
-        expect(page).to have_content(projects[8].title)
+        expect(page).to have_content(projects.sort_by(&:updated_at).reverse[8].title)
         find("a.paginate_button", text: 3).click
-        expect(page).to have_content(projects.last.title)
+        expect(page).to have_content(projects.sort_by(&:updated_at).reverse.last.title)
         find("a.paginate_button", text: "<").click
-        expect(page).to have_content(projects[14].title)
+        expect(page).to have_content(projects.sort_by(&:updated_at).reverse[14].title)
         find("a.paginate_button", text: "<").click
-        expect(page).to have_content(projects.first.title)
+        expect(page).to have_content(projects.sort_by(&:updated_at).reverse.first.title)
       end
     end
 


### PR DESCRIPTION
Closes #1078

I created and approved the projects in the following order to generate the screenshots below:

1. Created "pending 1"
2. Created "pending 2"
3. Created "pending 3"
4. Created "approved 1"
5. Created "approved 2"
6. Created "approved 3"
7. Approved "approved 1"
8. Approved "approved 2"
9. Created "pending 4"
10. Approved "approved 3"

## Screenshots:

### Admin dashboard:
![Screenshot 2024-12-05 at 4 25 19 PM](https://github.com/user-attachments/assets/5e3f57de-85a0-4964-9ff6-8a9b1c0fc66b)

### Projects dashboard:
![Screenshot 2024-12-05 at 4 25 08 PM](https://github.com/user-attachments/assets/e657ab08-757c-422d-9d13-fd8314b14e1b)

