### PR TITLE
Adding appropriate padding to the header

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -43,14 +43,13 @@
     width: 100% !important;
   }
 
-  .header-logo {
-    padding-left: 20px;
+  #header .navbar .header-logo {
+    padding-left: 1em;
   }
 
   #header-navigation {
     color: $white;
     margin: auto;
-    padding: 50px 25px 25px 25px;
     float: right;
     display: -webkit-inline-box;
     font-family: "Libre Franklin";
@@ -61,8 +60,7 @@
       font-style: normal;
       line-height: 24px;
       font-weight: 600;
-      margin-left: 12px;
-      margin-right: 12px;
+      margin-right: 1em;
     }
     .navbar-item a {
       color: $white;
@@ -79,7 +77,9 @@
       text-decoration: underline;
     }
     .dropdown-menu { 
-      left: -45px;
+      left: -5em;
+      --bs-dropdown-spacer: 1em;
+      --bs-dropdown-min-width: 10em;
     }
 
     .dropdown-menu a {

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,7 +2,7 @@
 <div id="header">
   <nav class="navbar navbar-expand-lg">
 
-<div class="row header-row">
+<div class="row header-row align-items-center">
 
   <div class="col-lg-3 header-logo">
     <a href="/"><%= image_tag("TigerData-LOGO-KO_wide2.svg", alt: "TigerData logo", size: "150x100", id: "logo") %></a>


### PR DESCRIPTION
refs #983 

Note padding around logo, the menus are now centered, and the pop up menu is entirely displayed

![Screenshot 2024-12-06 at 9 54 31 AM](https://github.com/user-attachments/assets/3ec65529-1723-469b-9084-dc3745b7b294)

![Screenshot 2024-12-06 at 9 54 15 AM](https://github.com/user-attachments/assets/08f219d3-f882-46c7-92c8-a64c1baea73a)
