### PR TITLE
Fixed flash message logic and behavior

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -5,6 +5,7 @@
 #header {
     padding: 0px;
     background-color: $black;
+    margin-bottom: 1em;
 
     .navbar-brand {
         color: $white;

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -12,7 +12,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       flash.alert = "You are not a recognized CAS user."
     else
       sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
-      flash.notice = "Welcome, #{@user.given_name}"
     end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,8 +43,12 @@
       <% if flash[:notice] or flash[:alert] %>
         <div class="row">
           <div class="col">
+          <% if flash[:notice]%>
             <div class="alert alert-primary" role="alert" ><%= flash[:notice] %></div>
+          <% end %>
+          <% if flash[:alert]%> 
             <div class="alert alert-warning" role="alert"><%= flash[:alert] %></div>
+          <% end %> 
           </div>
         </div>
       <% end %>

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Users::OmniauthCallbacksController do
       allow(User).to receive(:from_cas) { project_sponsor }
       get :cas
       expect(response).to redirect_to(root_path)
-      expect(flash.notice).to eq("Welcome, #{project_sponsor.given_name}")
     end
   end
 


### PR DESCRIPTION
Closes #1106 

## Screenshots:

### Upon login:
![Screenshot 2024-12-11 at 1 43 17 PM](https://github.com/user-attachments/assets/7607e440-3f13-4fc5-a9da-b2911416f07e)

### Upon logout: 
![Screenshot 2024-12-11 at 1 42 59 PM](https://github.com/user-attachments/assets/d93d15b1-ed18-4673-9504-f31364b42a46)

### When there is a warning:
![Screenshot 2024-12-11 at 1 43 59 PM](https://github.com/user-attachments/assets/34b23e49-7126-45e4-86f0-7680ae209f57)
