### PR TITLE
Fixed bug in download link in modal

### DIFF
--- a/app/views/projects/_latest_download_link.html.erb
+++ b/app/views/projects/_latest_download_link.html.erb
@@ -1,1 +1,1 @@
-<%= link_to("Download latest report - generated #{time_ago_in_words(@latest_completed_download.completion_time)} ago", project_file_list_download_path(@latest_completed_download.id, target: "_blank")) %>
+<%= link_to("Download latest report - generated #{time_ago_in_words(@latest_completed_download.completion_time)} ago", project_file_list_download_path(job_id: @latest_completed_download.job_id, target: "_blank")) %>

--- a/spec/system/project_details_spec.rb
+++ b/spec/system/project_details_spec.rb
@@ -212,16 +212,13 @@ RSpec.describe "Project Details Page", type: :system, connect_to_mediaflux: true
 
       context "when downloads exist" do
         before do
-          FileInventoryRequest.create!(user_id: sponsor_user.id, project_id: project.id, job_id: 123, state: UserRequest::COMPLETED,
-                                       request_details: { project_title: project.title }, completion_time: 5.days.ago)
-          FileInventoryRequest.create!(user_id: sponsor_user.id, project_id: project.id, job_id: 456, state: UserRequest::COMPLETED,
-                                       request_details: { project_title: project.title }, completion_time: 2.days.ago)
+          FileInventoryJob.new(user_id: sponsor_user.id, project_id: project.id).perform_now
         end
         it "includes a link to the latest download in the download modal" do
           sign_in sponsor_user
           visit "/projects/#{project.id}"
           click_on("Download Complete List")
-          expect(page).to have_content("Download latest report - generated 2 days ago")
+          expect(page).to have_content("Download latest report - generated less than a minute ago")
         end
       end
     end


### PR DESCRIPTION
The download link that appears in the modal does not actually trigger the file download.  This PR should fix that.