### PR TITLE
Allowing the user mediaflux session to be passed to the inventory job

### DIFF
--- a/app/jobs/file_inventory_job.rb
+++ b/app/jobs/file_inventory_job.rb
@@ -18,12 +18,15 @@ class FileInventoryJob < ApplicationJob
     end
   end
 
-  def perform(user_id:, project_id:)
+  def perform(user_id:, project_id:, mediaflux_session:)
     project = Project.find(project_id)
     raise "Invalid project id #{project_id} for job #{job_id}" if project.nil?
     user = User.find(user_id)
     raise "Invalid user id #{user_id} for job #{job_id}" if user.nil?
     Rails.logger.debug inspect
+
+    # set the mediaflux session to the one the user created, do not just utilize the system one
+    user.mediaflux_from_session({ mediaflux_session: })
 
     # Queries Mediaflux for the file list and saves it to a CSV file.
     filename = filename_for_export

--- a/app/services/project_job_service.rb
+++ b/app/services/project_job_service.rb
@@ -6,7 +6,7 @@ class ProjectJobService
   end
 
   def list_contents_job(user:)
-    job = FileInventoryJob.perform_later(user_id: user.id, project_id: @project.id)
+    job = FileInventoryJob.perform_later(user_id: user.id, project_id: @project.id, mediaflux_session: user.mediaflux_session)
     # Log the job id and the Sidekiq JID in case we need to troubleshoot the job
     # https://github.com/sidekiq/sidekiq/wiki/Active-Job#job-id
     Rails.logger.info("Job scheduled, job id: #{job.job_id}, (Sidekiq JID: #{job.provider_job_id || 'nil'})")

--- a/spec/jobs/file_inventory_cleanup_job_spec.rb
+++ b/spec/jobs/file_inventory_cleanup_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe FileInventoryCleanupJob, connect_to_mediaflux: true, type: :job d
 
   describe "#perform_now" do
     it "deletes any files older than 7 days" do
-      req = FileInventoryJob.perform_now(user_id: user.id, project_id: project_in_mediaflux.id)
+      req = FileInventoryJob.perform_now(user_id: user.id, project_id: project_in_mediaflux.id, mediaflux_session: user.mediaflux_session)
       req.completion_time = eight_days_ago
       req.save
 
@@ -22,7 +22,7 @@ RSpec.describe FileInventoryCleanupJob, connect_to_mediaflux: true, type: :job d
     end
 
     it "marks the file inventory request stale" do
-      req = FileInventoryJob.perform_now(user_id: user.id, project_id: project_in_mediaflux.id)
+      req = FileInventoryJob.perform_now(user_id: user.id, project_id: project_in_mediaflux.id, mediaflux_session: user.mediaflux_session)
       req.completion_time = eight_days_ago
       req.save
 

--- a/spec/jobs/file_inventory_job_spec.rb
+++ b/spec/jobs/file_inventory_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe FileInventoryJob, connect_to_mediaflux: true do
     it "creates a file inventory request attached to the user and the project" do
       expect(FileInventoryRequest.count).to be 0
       perform_enqueued_jobs do
-        FileInventoryJob.perform_later(user_id: user.id, project_id: project_in_mediaflux.id)
+        FileInventoryJob.perform_later(user_id: user.id, project_id: project_in_mediaflux.id, mediaflux_session: user.mediaflux_session)
       end
       expect(FileInventoryRequest.count).to be 1
       file_inventory_request = FileInventoryRequest.first
@@ -27,33 +27,33 @@ RSpec.describe FileInventoryJob, connect_to_mediaflux: true do
     # let(:file_inventory_job) { described_class.perform_now(user_id:, project_id:) }
     it "creates a file inventory request attached to the user and the project" do
       expect(FileInventoryRequest.count).to be 0
-      FileInventoryJob.perform_now(user_id: user.id, project_id: project_in_mediaflux.id)
+      FileInventoryJob.perform_now(user_id: user.id, project_id: project_in_mediaflux.id, mediaflux_session: user.mediaflux_session)
       expect(FileInventoryRequest.count).to be 1
       file_inventory_request = FileInventoryRequest.first
       expect(file_inventory_request.state).to eq UserRequest::COMPLETED
     end
 
     it "saves the output to a file" do
-      file_inventory_request = described_class.perform_now(user_id: user.id, project_id: project_in_mediaflux.id)
+      file_inventory_request = described_class.perform_now(user_id: user.id, project_id: project_in_mediaflux.id, mediaflux_session: user.mediaflux_session)
       output_file = Pathname.new(Rails.configuration.mediaflux["shared_files_location"]).join("#{file_inventory_request.job_id}.csv").to_s
       expect(File.exist?(output_file)).to be true
     end
 
     it "puts the file path into the file inventory request" do
-      file_inventory_request = described_class.perform_now(user_id: user.id, project_id: project_in_mediaflux.id)
+      file_inventory_request = described_class.perform_now(user_id: user.id, project_id: project_in_mediaflux.id, mediaflux_session: user.mediaflux_session)
       output_file = Pathname.new(Rails.configuration.mediaflux["shared_files_location"]).join("#{file_inventory_request.job_id}.csv").to_s
       file_inventory_request = FileInventoryRequest.first
       expect(file_inventory_request.output_file).to eq(output_file)
     end
 
     it "puts the title into the file inventory request" do
-      described_class.perform_now(user_id: user.id, project_id: project_in_mediaflux.id)
+      described_class.perform_now(user_id: user.id, project_id: project_in_mediaflux.id, mediaflux_session: user.mediaflux_session)
       file_inventory_request = FileInventoryRequest.first
       expect(file_inventory_request.request_details["project_title"]).to eq(project_in_mediaflux.title)
     end
 
     it "puts the completion time into the file inventory request" do
-      described_class.perform_now(user_id: user.id, project_id: project_in_mediaflux.id)
+      described_class.perform_now(user_id: user.id, project_id: project_in_mediaflux.id, mediaflux_session: user.mediaflux_session)
       file_inventory_request = FileInventoryRequest.first
       expect(file_inventory_request.completion_time).to be_instance_of(ActiveSupport::TimeWithZone)
     end
@@ -61,7 +61,7 @@ RSpec.describe FileInventoryJob, connect_to_mediaflux: true do
     context "when an invalid User ID is specified" do
       it "raises an error" do
         expect do
-          described_class.perform_now(user_id: "invalid-id", project_id: project_in_mediaflux.id)
+          described_class.perform_now(user_id: "invalid-id", project_id: project_in_mediaflux.id, mediaflux_session: user.mediaflux_session)
         end.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find User/)
       end
     end

--- a/spec/system/project_details_spec.rb
+++ b/spec/system/project_details_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe "Project Details Page", type: :system, connect_to_mediaflux: true
 
       context "when downloads exist" do
         before do
-          FileInventoryJob.new(user_id: sponsor_user.id, project_id: project.id).perform_now
+          FileInventoryJob.new(user_id: sponsor_user.id, project_id: project.id, mediaflux_session: sponsor_user.mediaflux_session).perform_now
         end
         it "includes a link to the latest download in the download modal" do
           sign_in sponsor_user

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "WelcomeController", connect_to_mediaflux: true, js: true do
 
       it "shows the latests downloads available" do
         approved_project = Project.users_projects(current_user).first
-        FileInventoryJob.new(user_id: current_user.id, project_id: approved_project.id).perform_now
+        FileInventoryJob.new(user_id: current_user.id, project_id: approved_project.id, mediaflux_session: current_user.mediaflux_session).perform_now
         sign_in current_user
         visit "/"
         expect(page).to have_content "Latest Downloads"


### PR DESCRIPTION
This means the file will be generated in the user's mediaflux context instead of the system mediaflux context.

Which means id the user can not access the files they will not be shown.

fixes #1133