### PR TITLE
Ensure the footer is affixed appropriately to the bottom of the viewport

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,7 +28,7 @@
 
   </head>
 
-  <body>
+  <body class="d-flex flex-column min-vh-100">
     <%= render partial: 'shared/alternate_mediaflux' %>
     <%= render partial: 'shared/banner' %>
     <%= render partial: 'shared/header' %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer>
+<footer class="mt-auto">
    <div id="footer">
    <div class="content">
       <div class="logos">


### PR DESCRIPTION
I noticed that the footer was floating up from the bottom of the page during a demo this morning.  Adding these bootstrap classes should address that.