### PR TITLE
align dashboard tabs to left

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -63,7 +63,6 @@
   #dashboard-nav{
     @include tab-nav;
     display: flex;
-    justify-content: space-between;
     align-items: center;
     align-self: stretch;
   }


### PR DESCRIPTION
ref #1138 

Screenshot: 
Project tab:
<img width="1501" alt="image" src="https://github.com/user-attachments/assets/e0109bd9-8531-4b7c-8a76-8e14998e80ff" />

Admin tab:
<img width="1506" alt="image" src="https://github.com/user-attachments/assets/0d5268ff-e444-4262-a208-2cc8522af2b9" />

