### PR TITLE
Ensuring that the "Administration" tab is not rendered for superusers…

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -65,6 +65,8 @@
     display: flex;
     align-items: center;
     align-self: stretch;
+
+    border-bottom: 1.5px solid rgba(208, 208, 208, 1);
   }
 }
 #emulation_bar {

--- a/app/views/welcome/_logged_in.html.erb
+++ b/app/views/welcome/_logged_in.html.erb
@@ -11,7 +11,13 @@
         <div class="main">
             <div id="dashboard-nav">
                 <button id="dash-projects" class="tab-nav"> Projects </button>
-                <button id="dash-admin" class="tab-nav"> Administration </button>
+                <% if current_user.eligible_sysadmin? %>
+                    <button id="dash-admin" class="tab-nav"> Administration </button>
+                <% elsif current_user.trainer? %>
+                    <% if session[:emulation_role] == "System Administrator" %>
+                        <button id="dash-admin" class="tab-nav"> Administration </button>
+                    <% end %>
+                <% end %>
             </div>
             <% if @dash_session == "project"%>
                 <%= render partial: "projects_listing", locals: { projects: @dashboard_projects.sort_by(&:updated_at).reverse,  table_id: "projects-listing" } %>

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -40,6 +40,18 @@ RSpec.describe WelcomeController do
         expect(assigns(:current_user).eligible_sponsor).to be_falsey
         expect(assigns(:current_user).eligible_manager).to be_falsey
       end
+
+      context "when emulating the role of System Administrator" do
+        render_views
+
+        it "shows the admin tab" do
+          user.trainer = true
+          user.save!
+          get :index, session: { emulation_role: "System Administrator" }
+          expect(response).to render_template("index")
+          expect(response.body).to include("Administration")
+        end
+      end
     end
     context "when a trainer is emulating eligible_sponsor" do
       it "renders the index page" do
@@ -92,6 +104,26 @@ RSpec.describe WelcomeController do
     it "renders the styles preview page" do
       get :styles_preview
       expect(response).to render_template("styles_preview")
+    end
+
+    context "and the user is a sysadmin" do
+      let(:user) { FactoryBot.create :sysadmin, mediaflux_session: SystemUser.mediaflux_session }
+      render_views
+
+      it "shows the admin tab" do
+        get :index
+        expect(response.body).to include("Administration")
+      end
+    end
+
+    context "and the user is a superuser" do
+      let(:user) { FactoryBot.create :superuser, mediaflux_session: SystemUser.mediaflux_session }
+      render_views
+
+      it "shows the admin tab" do
+        get :index
+        expect(response.body).to include("Administration")
+      end
     end
   end
 end

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe "WelcomeController", connect_to_mediaflux: true, js: true do
       visit project_path(project)
       expect(page).to have_content "You need to sign in or sign up before continuing."
     end
+
+    it "hides the 'Administration' tab" do
+      visit "/"
+      expect(page).to have_content "TigerData Web Portal"
+      expect(page).not_to have_content "Administration"
+    end
   end
 
   context "authenticated user" do
@@ -79,6 +85,12 @@ RSpec.describe "WelcomeController", connect_to_mediaflux: true, js: true do
         expect(page).to have_content "Latest Downloads"
         expect(page).to have_content "Expires in 7 days"
         expect(page).to have_content "1.18 MB"
+      end
+
+      it "hides the 'Administration' tab" do
+        visit "/"
+        expect(page).to have_content "TigerData Web Portal"
+        expect(page).not_to have_content "Administration"
       end
 
       context "the user signed in is an eligible sponsor" do
@@ -179,6 +191,12 @@ RSpec.describe "WelcomeController", connect_to_mediaflux: true, js: true do
         expect(page).to have_content("Pending Projects")
         expect(page).to have_content("Approved Projects")
       end
+
+      it "renders the 'Administration' tab" do
+        sign_in current_user
+        visit "/"
+        expect(page).to have_content "Administration"
+      end
     end
 
     context "for tester-trainers" do
@@ -217,6 +235,15 @@ RSpec.describe "WelcomeController", connect_to_mediaflux: true, js: true do
           .skipping(:'color-contrast') # false positives
           .excluding(".tt-hint") # Issue is in typeahead.js library
       end
+
+      it "hides the 'Administration' tab" do
+        sign_in current_user
+        current_user.trainer = true
+        current_user.save!
+
+        visit "/"
+        expect(page).not_to have_content "Administration"
+      end
     end
 
     context "with the sysadmin role" do
@@ -237,6 +264,12 @@ RSpec.describe "WelcomeController", connect_to_mediaflux: true, js: true do
         expect(page).to have_content("Pending Projects")
         expect(page).to have_content("Approved Projects")
         expect(page).to have_content("Activity")
+      end
+
+      it "renders the 'Administration' tab" do
+        sign_in current_user
+        visit "/"
+        expect(page).to have_content "Administration"
       end
     end
   end


### PR DESCRIPTION
Resolves #1231 by addressing the following:
- Ensuring that the "Administration" tab is not rendered for superusers, sysadmins, and trainer users emulating the role of sysadmin
- Adding the bottom border underneath the navigation tabs for the welcome view