### PR TITLE
Utilize the main-content style on the logged in dashboard

### DIFF
--- a/app/assets/stylesheets/_dashboard.scss
+++ b/app/assets/stylesheets/_dashboard.scss
@@ -287,13 +287,7 @@
   }
 }
 
-.welcome-container {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 3.75rem;
-  align-self: stretch;
-
+.main-content {
   .welcome-pane {
     display: flex;
     justify-content: space-between;

--- a/app/views/welcome/_logged_in.html.erb
+++ b/app/views/welcome/_logged_in.html.erb
@@ -1,4 +1,4 @@
-<div class="welcome-container">
+<div class="main-content">
     <div class="welcome-pane">
         <h1>Welcome, <%= current_user.given_name %>!</h1>
         <div class="project-button">


### PR DESCRIPTION
Make the padding consistent between individual projects displays and the dashboard display

Before PR
![Screenshot 2025-01-31 at 12 28 09 PM](https://github.com/user-attachments/assets/08de5fc5-f94e-4cbf-a2b9-b307295b7862)

After PR:
![Screenshot 2025-01-31 at 12 27 47 PM](https://github.com/user-attachments/assets/af90b0aa-b46c-43bc-9e9d-d43cb3a2e9dd)
