### PR TITLE
remove the additional Recent Activity from the bottom of the Administration tab

### DIFF
--- a/app/views/dashboard/_admin_listing.html.erb
+++ b/app/views/dashboard/_admin_listing.html.erb
@@ -16,8 +16,5 @@
         <p> (none) </p>
       <% end %>
    </div>
-   <% unless current_user.superuser? %>
-   <%= render partial: "recent_activity" %>
-   <% end %>
    <%end%>
 </div>

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -250,7 +250,8 @@ RSpec.describe "Dashboard", connect_to_mediaflux: true, js: true do
         click_on "Administration"
         expect(page).to have_content("Pending Projects")
         expect(page).to have_content("Approved Projects")
-        expect(page).to have_content("Activity")
+        expect(page).to have_content "project 111"
+        expect(page).to have_content "project 444"
       end
 
       it "renders the 'Administration' tab" do


### PR DESCRIPTION
Before PR:
![Screenshot 2025-02-11 at 10 17 40 AM](https://github.com/user-attachments/assets/c8114a2b-d69e-473a-ac1e-ba5d2e56838d)

After PR:
![Screenshot 2025-02-11 at 10 24 53 AM](https://github.com/user-attachments/assets/d50d9364-c238-4337-aff8-08c4b5124116)
