### PR TITLE
Fixing emulator render text

### DIFF
--- a/app/helpers/emulator_helper.rb
+++ b/app/helpers/emulator_helper.rb
@@ -21,7 +21,7 @@ module EmulatorHelper
 
   def otherpage?
     @current_role = check_role
-    return true unless current_page?("/dashbaord")
+    return true unless current_page?("/dashboard")
   end
 
   def check_role

--- a/app/views/shared/_emulator.html.erb
+++ b/app/views/shared/_emulator.html.erb
@@ -17,7 +17,7 @@
             </form>
         <%end%>
 
-        <%if otherpage?%>
+        <% if otherpage? %>
             <h1><%= sanitize @emulator_alt_title %></h1>
             <p><%= sanitize @emulator_alt_body, attributes: %w(href target)%></p>
             <p><%=@current_role%></p>


### PR DESCRIPTION
Dashboard emulator was displaying emulator text twice.
Fixing bug caused by typo in the emulator helper