### PR TITLE
Add better logging

### DIFF
--- a/app/jobs/file_inventory_job.rb
+++ b/app/jobs/file_inventory_job.rb
@@ -52,12 +52,15 @@ class FileInventoryJob < ApplicationJob
     end
 
     def update_inventory_request(user_id:, project:, job_id:, filename: )
+      Rails.logger.info "Export - updating inventory request details for project #{project.id}"
       inventory_request = FileInventoryRequest.find_by(user_id: user_id, project_id: project.id, job_id: job_id)
       request_details = { output_file: filename, project_title: project.title, file_size: File.size(filename) }
       inventory_request.update(state: UserRequest::COMPLETED, request_details: request_details,
                                 completion_time: Time.current.in_time_zone("America/New_York"))
+      Rails.logger.info "Export - updated inventory request details for project #{project.id}"
       inventory_request
     rescue ActiveRecord::StatementInvalid
+      Rails.logger.info "Export - updating inventory request details for project #{project.id} failed, about to retry"
       ActiveRecord::Base.connection_pool.release_connection
       retry
     end


### PR DESCRIPTION
I have the sneaking suspicion that the code that updates the `FileInventoryRequest` is taking too long to complete. 

Twice I have seen the line in the log that indicates that the [file has been exported to disk](https://github.com/pulibrary/tigerdata-app/blob/main/app/jobs/file_inventory_job.rb#L35) and yet had to wait what feel like a long time to see the record in the database for the file inventory (which is what makes the result visible to the users) get updated. 

Notice the completion time for the job (16:48) is 15 minutes after the file was saved to disk (16:33):

```
#<FileInventoryRequest:0x00007effb9058cb8
  id: 9,
  user_id: 51,
  project_id: 8,
  job_id: "42aed9b9-08c8-4fd0-b649-7899b62b95bc",
  completion_time: Fri, 28 Feb 2025 16:48:57.095634000 UTC +00:00,
```

```
deploy@tigerdata-prod2:/opt/tigerdata/current$ ls -la /.../42aed9b9-08c8-4fd0-b649-7899b62b95bc.csv
-rw-rw-r-- 1 nobody nogroup 161322086 Feb 28 16:33 /.../42aed9b9-08c8-4fd0-b649-7899b62b95bc.csv
```

This PR does not fix the issue, but at least will give us some hard data rather than relying on my hunch.

Related to #1274

