### PR TITLE
Rake task to run a FileInventoryJob from the command line

### DIFF
--- a/app/jobs/file_inventory_job.rb
+++ b/app/jobs/file_inventory_job.rb
@@ -28,23 +28,11 @@ class FileInventoryJob < ApplicationJob
     # set the mediaflux session to the one the user created, do not just utilize the system one
     user.mediaflux_from_session({ mediaflux_session: })
 
-    # Get a MediaFlux session for the tigerdataapp user
-    api_domain = Rails.configuration.mediaflux["api_domain"]
-    api_user = Rails.configuration.mediaflux["api_user"]
-    api_password = Rails.configuration.mediaflux["api_password"]
-    logon_request = Mediaflux::LogonRequest.new(domain: api_domain, user: api_user, password: api_password, identity_token: nil, token_type: nil)
-    tigerdata_user_session = logon_request.session_token
-
-    # ======
-    # TEMPORARY: Run the job with the session for the tigerdataapp user
-    #
     # Queries Mediaflux for the file list and saves it to a CSV file.
     filename = filename_for_export
-    Rails.logger.info "Exporting file list to #{filename} for project #{project_id}"
-    Rails.logger.info "Export (session for #{user.uid}: #{mediaflux_session})"
-    Rails.logger.info "Export (session for tigerdataapp: #{tigerdata_user_session})"
-    project.file_list_to_file(session_id: tigerdata_user_session, filename: filename)
-    Rails.logger.info "Export file generated #{filename} for project #{project_id}"
+    Rails.logger.info "Exporting file list to #{filename} for project #{project_id} (session: #{mediaflux_session})"
+    project.file_list_to_file(session_id: mediaflux_session, filename: filename)
+    Rails.logger.info "Export file generated #{filename} for project #{project_id} (session: #{mediaflux_session})"
 
     # Update the job record as completed
     update_inventory_request(user_id: user.id, project: project, job_id: @job_id, filename: filename)

--- a/app/models/mediaflux/request.rb
+++ b/app/models/mediaflux/request.rb
@@ -153,7 +153,7 @@ module Mediaflux
         def build_http_request(name:, form_file: nil)
           request = self.class.build_post_request
 
-          Rails.logger.debug(xml_payload)
+          log_xml_request(xml_payload)
           set_authentication_headers(request)
 
           if form_file.nil?
@@ -171,6 +171,16 @@ module Mediaflux
           request
         end
       # rubocop:enable Metrics/MethodLength
+
+      def log_xml_request(xml_payload)
+        password_element = xml_payload.match(/\<password\>.*\<\/password\>/)
+        if password_element.nil?
+          Rails.logger.debug(xml_payload)
+        else
+          # Don't log the password
+          Rails.logger.debug(xml_payload.gsub(password_element.to_s, "<password>***</password>"))
+        end
+      end
 
       # Authentication code to push a few custom HTTP headers to Mediaflux
       # Eventually the `session_user` will need to be an object that provides the timeout value.

--- a/lib/tasks/file_inventory.rake
+++ b/lib/tasks/file_inventory.rake
@@ -23,7 +23,6 @@ namespace :file_inventory do
     netid = args[:netid]
     project = Project.find(project_id)
     user = User.where(uid: netid).first
-    mediaflux_session = nil
 
     # Lets the user enter the credentials to use (domain, username, password)
     # notice that the password is not displayed

--- a/lib/tasks/file_inventory.rake
+++ b/lib/tasks/file_inventory.rake
@@ -16,4 +16,36 @@ namespace :file_inventory do
     request.request_details = { file_size: File.size(filename), output_file: filename, project_title: request.project.title }
     request.save!
   end
+
+  desc "Runs a file inventory job (asks for the MediaFlux credentials to use)"
+  task :run, [:project_id, :netid] => [:environment] do |_, args|
+    project_id = args[:project_id]
+    netid = args[:netid]
+    project = Project.find(project_id)
+    user = User.where(uid: netid).first
+    mediaflux_session = nil
+
+    # Lets the user enter the credentials to use (domain, username, password)
+    # notice that the password is not displayed
+    puts "domain: "
+    mf_domain = STDIN.gets.chomp
+
+    puts "user: "
+    mf_user = STDIN.gets.chomp
+
+    puts "password: "
+    mf_password = STDIN.getpass.chomp
+
+    # Get a MediaFlux session for the credentials entered by the user
+    logon_request = Mediaflux::LogonRequest.new(domain: mf_domain, user: mf_user, password: mf_password, identity_token: nil, token_type: nil)
+    mediaflux_session = logon_request.session_token
+    if logon_request.error?
+      raise logon_request.response_error[:message]
+    end
+
+    # Schedule the file inventory job using the MediaFlux session we just adquired
+    puts "Scheduling file inventory using credentials for: #{mf_domain}:#{mf_user}, session: #{mediaflux_session}"
+    job_request = FileInventoryJob.perform_later(user_id: user.id, project_id: project.id, mediaflux_session: mediaflux_session)
+    puts "Scheduled file inventory #{job_request.job_id} for project #{project.title} (#{project.id}) user: #{user.uid} (#{user.id}), session: #{mediaflux_session}"
+  end
 end

--- a/lib/tasks/file_inventory.rake
+++ b/lib/tasks/file_inventory.rake
@@ -26,6 +26,7 @@ namespace :file_inventory do
 
     # Lets the user enter the credentials to use (domain, username, password)
     # notice that the password is not displayed
+    puts "Enter the credentials to connect to MediaFlux"
     puts "domain: "
     mf_domain = STDIN.gets.chomp
 


### PR DESCRIPTION
Added a Rake task that kicks off the FileInventoryJob for a given project. It assigns the job to the user indicated in the Rake task but allows you to specify the user credentials (domain,user,password) that will be used to connect to MediaFlux. This is to allows us to test with different accounts outside of the CAS authentication.

```
bundle exec rake:file_inventory:run[65,hc8719]
```

Where `65` is the `project_id` and `hc8719` is the `netid` of the user that the job will be assigned to. In the example above the job will show under my own Dashboard.

Notice that the MediaFlux credentials are prompted on the command line and the password is not written to the Rails log.

Part of #1274