### PR TITLE
Fix Chrome only bug to allow request to be saved if a custom storage has not been set

### DIFF
--- a/app/views/new_project_wizard/_form_project_storage.html.erb
+++ b/app/views/new_project_wizard/_form_project_storage.html.erb
@@ -35,7 +35,7 @@
           <div class="horizontal-frame">
             <div class="vertical-frame">
               <input class="form-input" type="number" name="request[storage_size]" id="storage_size"
-                    value="<%= storage_size %>" placeholder="Enter a value" min="1" step="1"></input>
+                    value="<%= storage_size %>" placeholder="Enter a value" min="0" step="1"></input>
               <div class="input-error">
                   <%= storage_size_error %>
               </div>


### PR DESCRIPTION
Allows chrome validations to pass if the integer value has been set to zero.  This does not occur in firefox, which is why our tests did not catch this issue