### PR TITLE
Refactoring ProjectXmlPresenter to ensure that certain XML Elements are not created when they are empty

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ group :development, :test do
   gem "ed25519"
   gem "factory_bot_rails", require: false
   gem "ffaker"
+  gem "pry-byebug"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,6 +300,9 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (5.0.5)
@@ -546,6 +549,7 @@ DEPENDENCIES
   net-ldap
   omniauth-cas (~> 3.0)
   pg
+  pry-byebug
   pry-rails
   puma (~> 5.6)
   rails (~> 7.0.4, >= 7.0.4.2)

--- a/app/models/project_metadata.rb
+++ b/app/models/project_metadata.rb
@@ -1,10 +1,70 @@
 # frozen_string_literal: true
+
+# rubocop:disable Metrics/ClassLength
 class ProjectMetadata
   DOI_NOT_MINTED = "DOI-NOT-MINTED"
 
-  attr_accessor :title, :description, :status, :data_sponsor, :data_manager, :departments, :data_user_read_only, :data_user_read_write,
+  # @return [String] The default directory protocol
+  def self.default_directory_protocol
+    "NFS"
+  end
+
+  # @return [String] The default project resource type
+  def self.default_resource_type
+    "TigerData Project"
+  end
+
+  # @return [String] The default HPC value
+  def self.default_hpc
+    "No"
+  end
+
+  # @return [String] The default project visibility
+  def self.default_project_visibility
+    "Restricted"
+  end
+
+  # @return [String] The default data use agreement
+  def self.default_data_use_agreement
+    "No"
+  end
+
+  # @return [Hash] The default globus request Hash entries
+  def self.default_globus_request
+    {
+      requested: false,
+      approved: false
+    }
+  end
+
+  # @return [Hash] The default Samba/SMB request Hash entries
+  def self.default_smb_request
+    {
+      requested: false,
+      approved: false
+    }
+  end
+
+  # @return [Boolean] The default value for whether a project is provisional
+  def self.default_provisionality
+    false
+  end
+
+
+  attr_accessor(
+    :title, :description, :status, :data_sponsor, :data_manager, :departments, :data_user_read_only, :data_user_read_write,
     :created_on, :created_by, :project_id, :project_directory, :project_purpose, :storage_capacity, :storage_performance_expectations,
-    :updated_by, :updated_on, :approval_note, :schema_version, :submission
+    :updated_by, :updated_on, :approval_note, :schema_version, :submission,
+    # NOTE: The following attributes are required by the XML schema
+    :hpc,
+    :data_use_agreement,
+    :project_visibility,
+    :resource_type,
+    :project_directory_protocol,
+    :globus_request,
+    :smb_request,
+    :provisional
+  )
 
   def initialize
     @departments = []
@@ -24,7 +84,10 @@ class ProjectMetadata
     pm
   end
 
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/PerceivedComplexity
   def initialize_from_hash(metadata_hash)
     @title = metadata_hash[:title]
     @description = metadata_hash[:description]
@@ -46,9 +109,26 @@ class ProjectMetadata
     @created_on = metadata_hash[:created_on] if metadata_hash[:created_on]
     @updated_by = metadata_hash[:updated_by] if metadata_hash[:updated_by]
     @updated_on = metadata_hash[:updated_on] if metadata_hash[:updated_on]
+
+    # NOTE: The following attributes are required by the 0.8 XML schema
+    @hpc = metadata_hash[:hpc] || self.class.default_hpc
+
+    @data_use_agreement = metadata_hash[:data_use_agreement] || self.class.default_data_use_agreement
+
+    @project_visibility = metadata_hash[:project_visibility] || self.class.default_project_visibility
+    @resource_type = metadata_hash[:resource_type] || self.class.default_resource_type
+
+    @globus_request = metadata_hash[:globus_request] || self.class.default_globus_request
+    @smb_request = metadata_hash[:smb_request] || self.class.default_smb_request
+
+    @provisional = metadata_hash[:provisional] || self.class.default_provisionality
+
     set_defaults
   end
+  # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/AbcSize
 
   # Initializes the object with the values in the params (which is an ActionController::Parameters)
   def initialize_from_params(params)
@@ -190,3 +270,4 @@ class ProjectMetadata
         end
       end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/models/project_metadata.rb
+++ b/app/models/project_metadata.rb
@@ -50,7 +50,6 @@ class ProjectMetadata
     false
   end
 
-
   attr_accessor(
     :title, :description, :status, :data_sponsor, :data_manager, :departments, :data_user_read_only, :data_user_read_write,
     :created_on, :created_by, :project_id, :project_directory, :project_purpose, :storage_capacity, :storage_performance_expectations,

--- a/app/presenters/project_show_presenter.rb
+++ b/app/presenters/project_show_presenter.rb
@@ -75,18 +75,21 @@ class ProjectShowPresenter
 
   def quota_usage(session_id:)
     if project.pending?
-      quota_usage = "0 KB out of 0 GB used"
+      "0 KB out of 0 GB used"
     else
-      quota_usage = "#{project.storage_usage(session_id:)} out of #{project.storage_capacity(session_id:)} used"
+      "#{project.storage_usage(session_id:)} out of #{project.storage_capacity(session_id:)} used"
     end
-    quota_usage
   end
 
   def quota_percentage(session_id:)
-    return 0 if project.pending? || project.storage_capacity_raw(session_id:).zero?
-    
-   (project.storage_usage_raw(session_id:).to_f / project.storage_capacity_raw(session_id:).to_f) * 100
-  end  
+    return 0 if project.pending?
+
+    storage_capacity = project.storage_capacity_raw(session_id:)
+    return 0 if storage_capacity.zero?
+
+    storage_usage = project.storage_usage_raw(session_id:)
+    (storage_usage.to_f / storage_capacity.to_f) * 100
+  end
 
   private
 

--- a/app/presenters/project_xml_presenter.rb
+++ b/app/presenters/project_xml_presenter.rb
@@ -109,6 +109,8 @@ class ProjectXmlPresenter
     project_status = project.status
     return if project_status.nil?
 
+    return "AdminReview" if project_status == Project::PENDING_STATUS
+
     project_status.capitalize
   end
 
@@ -146,7 +148,7 @@ class ProjectXmlPresenter
 
   # @return [String] The date and time of the approval
   def approval_date_time
-    return if approval_note.nil?
+    return nil if approval_note.nil?
 
     approval_note[:note_date_time]
   end
@@ -259,9 +261,9 @@ class ProjectXmlPresenter
 
     def builder
       @builder ||= begin
-                         builder_args = find_builder_args(:resource)
-                         XmlTreeBuilder.new(**builder_args)
-                       end
+                     builder_args = find_builder_args(:resource)
+                     XmlTreeBuilder.new(**builder_args)
+                   end
     end
 
     delegate :build, to: :builder

--- a/app/presenters/project_xml_presenter.rb
+++ b/app/presenters/project_xml_presenter.rb
@@ -10,11 +10,12 @@ class ProjectXmlPresenter
     "in_mediaflux?",
     "mediaflux_id",
     "pending?",
-    "status",
     "title",
     to: :project
   )
+
   delegate(
+    "approval_note",
     "description",
     "data_manager",
     "data_sponsor",
@@ -29,30 +30,9 @@ class ProjectXmlPresenter
     "created_on",
     "updated_by",
     "updated_on",
-    "approval_note",
     "schema_version",
     to: :project_metadata
   )
-
-  # @return [String] The default directory protocol
-  def self.default_directory_protocol
-    "NFS"
-  end
-
-  # @return [String] The default project resource type
-  def self.default_project_resource_type
-    "TigerData Project"
-  end
-
-  # @return [String] The default HPC value
-  def self.default_hpc
-    "No"
-  end
-
-  # @return [String] The default project visibility
-  def self.default_project_visibility
-    "Restricted"
-  end
 
   # @param project [Project] The project for the presenter
   def initialize(project)
@@ -65,27 +45,71 @@ class ProjectXmlPresenter
 
   # @return [Boolean] Whether the request for a Globus mount is approved
   def globus_enable_approved?
-    false
+    globus_request = project_metadata.globus_request
+    globus_request[:approved] || false
+  end
+
+  # @return [String] Whether the request for a Globus mount is approved
+  def globus_enable_approved
+    if globus_enable_approved?
+      "true"
+    else
+      "false"
+    end
   end
 
   # @return [Boolean] Whether there is a request for a Globus mount
   def globus_enable_requested?
-    false
+    globus_request = project_metadata.globus_request
+    globus_request.present?
+  end
+
+  # @return [String] Whether the request for a Globus mount is requested
+  def globus_enable_requested
+    if globus_enable_requested?
+      "true"
+    else
+      "false"
+    end
   end
 
   # @return [Boolean] Whether the request for the SMB mount is approved
   def smb_enable_approved?
-    false
+    smb_request = project_metadata.smb_request
+    smb_request[:approved] || false
+  end
+
+  # @return [String] Whether the request for the SMB mount is approved
+  def smb_enable_approved
+    if smb_enable_approved?
+      "true"
+    else
+      "false"
+    end
   end
 
   # @return [Boolean] Whether there is a request for SMB mount
   def smb_enable_requested?
-    false
+    smb_request = project_metadata.smb_request
+    smb_request.present?
   end
 
-  # @return [String] The project status
+  # @return [String] Whether the request for the SMB mount is requested
+  def smb_enable_requested
+    if smb_enable_requested?
+      "true"
+    else
+      "false"
+    end
+  end
+
+  # @return [String] The project status (mapped to values specified by the TigerData XML schema)
+  # NOTE: Valid values are one of: 'AdminReview', 'Approved', 'Active', 'Retired', 'Published'
   def status
-    "Active"
+    project_status = project.status
+    return if project_status.nil?
+
+    project_status.capitalize
   end
 
   # @return [ProvenanceEvent] The first project submission event
@@ -115,52 +139,58 @@ class ProjectXmlPresenter
 
   # @return [String] The user ID of the user who approved the project
   def approved_by
-    "abdc12"
+    return if approval_note.nil?
+
+    approval_note[:note_by]
   end
 
   # @return [String] The date and time of the approval
   def approval_date_time
-    "2025-03-28T15:34:11-04:00"
+    return if approval_note.nil?
+
+    approval_note[:note_date_time]
   end
 
   # @return [String] Whether or not the project data use agreement
   def data_use_agreement?
-    false
+    project_metadata.data_use_agreement.present?
   end
 
   # @return [String] The project resource type
   def project_resource_type
-    self.class.default_project_resource_type
+    project_metadata.resource_type
   end
 
   # @return [Boolean] Whether the project is provisional
   def provisional_project?
-    false
+    project_metadata.provisional
   end
 
   # @return [String] Whether or not the project is associated with HPC
-  def hpc
-    self.class.default_hpc
-  end
+  delegate :hpc, to: :project_metadata
 
   # @return [String] The project visibility
-  def project_visibility
-    self.class.default_project_visibility
-  end
+  delegate :project_visibility, to: :project_metadata
 
   # @return [Boolean] Whether the project directory request is approved
   def project_directory_approved?
-    false
+    expectations = storage_performance_expectations
+    expectations[:approved] || false
   end
 
   # @return [Boolean] Whether the project storage capacity request is approved
   def storage_capacity_approved?
-    false
+    storage_capacity_size = storage_capacity["size"] || {}
+    return false unless storage_capacity_size.key?(:approved)
+
+    approved_size = storage_capacity_size[:approved] || 0
+    approved_size > 0
   end
 
   # @return [Boolean] Whether the project storage request is approved
-  def storage_performance_approved?
-    false
+  def storage_performance_requested?
+    requested = storage_performance_expectations[:requested]
+    requested.present?
   end
 
   # @return [Array<String>] The project directory paths
@@ -185,7 +215,7 @@ class ProjectXmlPresenter
       value = segments[0]
       value.upcase
     else
-      self.class.default_directory_protocol
+      ProjectMetadata.default_directory_protocol
     end
   end
 

--- a/app/services/xml_element_builder.rb
+++ b/app/services/xml_element_builder.rb
@@ -1,6 +1,52 @@
 # frozen_string_literal: true
 class XmlElementBuilder < XmlNodeBuilder
-  attr_reader :presenter, :name, :allow_empty, :attributes, :content
+  attr_reader :presenter, :name, :attributes, :content
+  alias entry content
+
+  # @return [Nokogiri::XML::Element] the XML element node
+  def element
+    @element ||= begin
+                   created = @document.create_element(name)
+                   @document.root = created
+                   created
+                 end
+  end
+
+  # @return [Nokogiri::XML::Element] the XML element node
+  def build_attributes
+    attributes.each do |key, attr_entry|
+      value = attr_entry
+      if attr_entry.is_a?(Hash) && attr_entry.key?(:object_method)
+        allow_empty_attr = attr_entry.fetch(:allow_empty, true)
+
+        message = attr_entry[:object_method]
+        method_args = attr_entry[:args] || []
+        method_args = @default_method_args + method_args
+        value = presenter.send(message, *method_args)
+
+        raise ArgumentError, "Value for #{key} cannot be nil" if value.nil? && !allow_empty_attr
+      end
+
+      element[key] = value unless value.nil?
+    end
+
+    element
+  end
+
+  # @return [String] the content for the XML element
+  def build_content!
+    allow_empty_content = entry.fetch(:allow_empty, true)
+
+    message = entry[:object_method]
+    method_args = entry[:args] || []
+    method_args = @default_method_args + method_args
+    @content = presenter.send(message, *method_args)
+
+    raise ArgumentError, "Content for #{name} cannot be nil" if content.nil? && !allow_empty_content
+    content
+  end
+
+  delegate :blank?, to: :content
 
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/CyclomaticComplexity
@@ -9,72 +55,58 @@ class XmlElementBuilder < XmlNodeBuilder
   #
   # @return [Nokogiri::XML::Element]
   def build
-    super
-
-    element = document.create_element(name)
-
-    default_method_args = []
-    default_method_args << @index unless @index.nil?
-
-    attributes.each do |key, entry|
-      value = entry
-      if entry.is_a?(Hash) && entry.key?(:object_method)
-        message = entry[:object_method]
-        method_args = entry[:args] || []
-        method_args = default_method_args + method_args
-        value = presenter.send(message, *method_args)
-      end
-
-      # NOTE: If the configuration does not permit empty XML elements, then ensure that `element` is set to `nil` if it is empty.
-      unless element.nil?
-        if !allow_empty && value.nil?
-          element = nil
-        else
-          element[key] = value
-        end
-      end
+    if entry.is_a?(Hash) && entry.key?(:object_method)
+      build_content!
     end
 
-    if content.is_a?(Hash) && content.key?(:object_method)
-      entry = content
-      message = entry[:object_method]
-      method_args = entry[:args] || []
-      method_args = default_method_args + method_args
-      content = presenter.send(message, *method_args)
+    built = build_attributes
+    built.content = content
 
-      # NOTE: If the configuration does not permit empty XML elements, then ensure that `element` is set to `nil` if it is empty.
-      if !allow_empty && content.blank?
-        element = nil
-      end
-    end
-
-    unless element.nil?
-      element.content = content
-    end
-
-    @node = element
+    built
+  rescue ArgumentError => arg_error
+    Rails.logger.warn("Error building XML project metadata: #{arg_error.message}")
+    nil
   end
   # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/AbcSize
 
+  # @return [Nokogiri::XML::Element] the XML element node
+  def node
+    @node ||= build
+  end
+
+  def add_child(child)
+    return if child.nil?
+
+    # @see https://nokogiri.org/rdoc/Nokogiri/XML/Node.html#method-i-clone
+    level = 1
+    cloned = child.clone(level, document)
+    node.add_child(cloned)
+
+    cloned
+  end
+
   # @param [ProjectXmlPresenter] presenter
   # @param [String] name
-  # @param [Boolean] allow_empty whether to allow the creation of XML elements with nil or empty content
   # @param [Hash] attributes
   # @param [String] content
   # @param [Integer] index the index for the element (when there are multiple sibling nodes)
-  # @param [Hash] kwargs
-  def initialize(presenter:, name:, allow_empty: true, attributes: {}, content: nil, index: nil, **kwargs)
-    super(**kwargs)
+  # @param [Hash] options
+  def initialize(presenter:, name:, attributes: {}, content: nil, index: nil, **options)
+    super(**options)
 
     @presenter = presenter
     @name = name
-    @allow_empty = allow_empty
+
     @attributes = attributes
     @content = content
 
     @index = index
+    # @allow_empty = allow_empty
+
+    @default_method_args = []
+    @default_method_args << @index unless @index.nil?
   end
 end

--- a/app/services/xml_node_builder.rb
+++ b/app/services/xml_node_builder.rb
@@ -23,7 +23,7 @@ class XmlNodeBuilder
 
   # @return [Nokogiri::XML::Element]
   def build
-    return @node unless @node.nil?
+    return unless @node.nil?
 
     @node = document.root
   end

--- a/app/services/xml_node_builder.rb
+++ b/app/services/xml_node_builder.rb
@@ -2,7 +2,7 @@
 class XmlNodeBuilder
   XML_VERSION = "1.0"
 
-  attr_accessor :document
+  attr_reader :document, :node
 
   # @return [String]
   def xml_version
@@ -23,7 +23,7 @@ class XmlNodeBuilder
 
   # @return [Nokogiri::XML::Element]
   def build
-    return unless @node.nil?
+    return node if node.present?
 
     @node = document.root
   end

--- a/app/services/xml_tree_builder.rb
+++ b/app/services/xml_tree_builder.rb
@@ -1,20 +1,53 @@
 # frozen_string_literal: true
+
+class XmlNullBuilder < XmlNodeBuilder
+  def build
+    document
+  end
+
+  def blank?
+    true
+  end
+
+  # No-op for null builder
+  def add_child(_child)
+    nil
+  end
+
+  def name
+    nil
+  end
+
+  def initialize(**_options)
+    super(document: nil)
+  end
+end
+
 class XmlTreeBuilder < XmlNodeBuilder
-  attr_reader :parent, :children
+  attr_reader :children, :root_builder_options
+
+  def null_builder
+    @null_builder ||= XmlNullBuilder.new(**root_builder_options)
+  end
+
+  def root_builder
+    @root_builder ||= begin
+                        default_builder = XmlElementBuilder.new(**root_builder_options)
+                        null_builder if default_builder.blank?
+                        default_builder
+                      end
+  end
+
+  delegate :node, :document, to: :root_builder
 
   # @return [Nokogiri::XML::Element]
   def build
-    super
-
-    built_children = children.map(&:build)
-    # NOTE: Handle cases where `#build` returns `nil` (XML element has `nil` or empty content).
-    nodes = built_children.reject(&:nil?)
+    nodes = children.map(&:build)
     nodes.each do |child|
-      parent.add_child(child)
+      root_builder.add_child(child)
     end
-    document.root = parent
 
-    @node = document.root
+    node
   end
 
   # rubocop:disable Metrics/AbcSize
@@ -26,21 +59,21 @@ class XmlTreeBuilder < XmlNodeBuilder
     instances = [:default]
     builders = entries.map do |child_entry|
       child_entry.values.map do |child_args|
-        multiple = child_args[:multiple] || false
+        multiple_children = child_args[:multiple] || false
 
-        if multiple
+        if multiple_children
           message = child_args[:object_method]
 
           method_args = child_args[:args] || []
-          instances = @parent_builder.presenter.send(message, *method_args)
+          instances = root_builder.presenter.send(message, *method_args)
         end
 
         instances.each_with_index.map do |_instance, i|
           builder_args = child_args.dup
-          builder_args[:presenter] = @parent_builder.presenter
+          builder_args[:presenter] = root_builder.presenter
           builder_args[:document] = document
 
-          if multiple
+          if multiple_children
             builder_args[:index] = i
             builder_args.delete(:multiple)
           end
@@ -56,20 +89,11 @@ class XmlTreeBuilder < XmlNodeBuilder
   # rubocop:enable Metrics/AbcSize
 
   # @param children [Array<XmlNodeBuilder>] XmlNodeBuilder objects for the child nodes in the XML tree
-  # @param kwargs [Hash] keyword arguments for the parent XmlElementBuilder
-  def initialize(children: [], **kwargs)
-    @parent_builder = XmlElementBuilder.new(**kwargs)
-    @parent = @parent_builder.build
-
-    # NOTE: Handle cases where `#build` returns `nil` (XML element has `nil` or empty content).
-    document = if @parent.nil?
-                 nil
-               else
-                 @parent.document
-               end
+  # @param options [Hash] arguments for the root XmlElementBuilder
+  def initialize(children: [], **options)
+    @root_builder_options = options.dup
+    @children = parse_child_entries(children)
 
     super(document: document)
-
-    @children = parse_child_entries(children)
   end
 end

--- a/app/services/xml_tree_builder.rb
+++ b/app/services/xml_tree_builder.rb
@@ -6,7 +6,9 @@ class XmlTreeBuilder < XmlNodeBuilder
   def build
     super
 
-    nodes = children.map(&:build)
+    built_children = children.map(&:build)
+    # NOTE: Handle cases where `#build` returns `nil` (XML element has `nil` or empty content).
+    nodes = built_children.reject(&:nil?)
     nodes.each do |child|
       parent.add_child(child)
     end
@@ -59,7 +61,14 @@ class XmlTreeBuilder < XmlNodeBuilder
     @parent_builder = XmlElementBuilder.new(**kwargs)
     @parent = @parent_builder.build
 
-    super(document: @parent.document)
+    # NOTE: Handle cases where `#build` returns `nil` (XML element has `nil` or empty content).
+    document = if @parent.nil?
+                 nil
+               else
+                 @parent.document
+               end
+
+    super(document: document)
 
     @children = parse_child_entries(children)
   end

--- a/config/xml_builder.yml
+++ b/config/xml_builder.yml
@@ -154,7 +154,7 @@ project:
             discoverable: "false"
             trackingLevel: InternalUseOnly
             approved:
-              object_method: storage_performance_approved?
+              object_method: storage_performance_requested? # NOTE: Please see ProjectMetadata#update_storage_performance_expectations for why we do not let users specify the approved value
           children:
             - requested_value:
                 name: requestedValue
@@ -207,38 +207,38 @@ project:
                   - smb_enable_setting:
                       name: smbEnableSetting
                       content:
-                        object_method: smb_enable_approved?
+                        object_method: smb_enable_approved
 
                   - requested_value:
                       name: requestedValue
                       content:
-                        object_method: smb_enable_requested?
+                        object_method: smb_enable_requested
 
                   - approved_value:
                       name: approvedValue
                       content:
-                        object_method: smb_enable_approved?
+                        object_method: smb_enable_approved
 
             - globus_enable:
                 name: globusEnable
                 attributes:
                   approved:
-                    object_method: globus_enable_approved?
+                    object_method: globus_enable_approved
                 children:
                   - globus_enable_setting:
                       name: globusEnableSetting
                       content:
-                        object_method: globus_enable_requested?
+                        object_method: globus_enable_approved
 
                   - requested_value:
                       name: requestedValue
                       content:
-                        object_method: globus_enable_approved?
+                        object_method: globus_enable_requested
 
                   - approved_value:
                       name: approvedValue
                       content:
-                        object_method: globus_enable_approved?
+                        object_method: globus_enable_approved
 
         #<projectPurpose inherited="true" discoverable="true" trackingLevel="InternalUseOnly">Research</projectPurpose>
         project_purpose:
@@ -313,6 +313,7 @@ project:
 
                   - approved_by:
                       name: approvedBy
+                      allow_empty: false
                       attributes:
                         userID:
                           object_method: approved_by
@@ -320,6 +321,7 @@ project:
 
                   - approval_date_time:
                       name: approvalDateTime
+                      allow_empty: false
                       content:
                         object_method: approval_date_time
 

--- a/config/xml_builder.yml
+++ b/config/xml_builder.yml
@@ -313,16 +313,16 @@ project:
 
                   - approved_by:
                       name: approvedBy
-                      allow_empty: false
                       attributes:
                         userID:
+                          allow_empty: false
                           object_method: approved_by
                         userIDType: NetID
 
                   - approval_date_time:
                       name: approvalDateTime
-                      allow_empty: false
                       content:
+                        allow_empty: false
                         object_method: approval_date_time
 
             - status:

--- a/spec/mailers/tigerdata_spec.rb
+++ b/spec/mailers/tigerdata_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe TigerdataMailer, type: :mailer do
   let(:project) { FactoryBot.create :project, project_id: "abc123/def" }
   let(:project_id) { project.id }
 
-  it "Sends project creation reuests" do
+  it "Sends project creation requests" do
     expect { described_class.with(project_id:).project_creation.deliver }.to change { ActionMailer::Base.deliveries.count }.by(1)
     mail = ActionMailer::Base.deliveries.last
 
@@ -17,6 +17,16 @@ RSpec.describe TigerdataMailer, type: :mailer do
     expect(html_body).to have_content(project.metadata_model.title)
     project.metadata.keys.each do |field|
       next if ["updated_on", "created_on", "created_by", "updated_by", "departments", "submission"].include?(field)
+      # NOTE: These are not included for 0.6 schema project creation requests
+      next if [
+        "hpc",
+        "data_use_agreement",
+        "project_visibility",
+        "resource_type",
+        "globus_request",
+        "smb_request",
+        "provisional"
+      ].include?(field)
 
       value = project.metadata[field]
       value = value.sort.join(", ") if value.is_a? Array

--- a/spec/system/project_spec.rb
+++ b/spec/system/project_spec.rb
@@ -648,8 +648,9 @@ RSpec.describe "Project Page", connect_to_mediaflux: true, type: :system  do
             xml = page.body
             expect(xml).to include("<projectDirectoryPath protocol=\"NFS\">#{approved_project.project_directory}</projectDirectoryPath>")
             expect(xml).to include("<title inherited=\"false\" discoverable=\"true\" trackingLevel=\"ResourceRecord\">#{approved_project.title}</title>")
-            expect(xml).to include("<storageCapacity approved=\"false\" inherited=\"false\" discoverable=\"false\" trackingLevel=\"InternalUseOnly\"/>")
-            expect(xml).to include("<storagePerformance inherited=\"false\" discoverable=\"false\" trackingLevel=\"InternalUseOnly\" approved=\"false\">")
+            # NOTE: 500 GB are available, hence the request was approved
+            expect(xml).to include("<storageCapacity approved=\"true\" inherited=\"false\" discoverable=\"false\" trackingLevel=\"InternalUseOnly\"/>")
+            expect(xml).to include("<storagePerformance inherited=\"false\" discoverable=\"false\" trackingLevel=\"InternalUseOnly\" approved=\"true\">")
             expect(xml).to include("<requestedValue>Standard</requestedValue>")
             expect(xml).to include("</storagePerformance>")
             expect(xml).to include("<projectPurpose inherited=\"true\" discoverable=\"true\" trackingLevel=\"InternalUseOnly\">Research</projectPurpose>")


### PR DESCRIPTION
Refactoring ProjectXmlPresenter to improve parsing for certain Project metadata values. Also ensures that certain XML elements cannot be created with empty content (these would otherwise invalidate the XML Document). Closes #1413 