### PR TITLE
Cosmetic adjustments to the New Project Request wizard

### DIFF
--- a/app/assets/stylesheets/_wizard.scss
+++ b/app/assets/stylesheets/_wizard.scss
@@ -92,7 +92,7 @@
               color: $gray-60;
 
               /* Heading 4 */
-              font-family: libre-franklin;
+              font-family: $libre-franklin;
               font-size: 1.5rem;
               font-style: normal;
               font-weight: 600;

--- a/app/views/new_project_wizard/project_information_categories.html.erb
+++ b/app/views/new_project_wizard/project_information_categories.html.erb
@@ -1,5 +1,6 @@
 <% content_for :title, "New Project Request" %>
 <% content_for :form_title, "Categories" %>
+<% content_for :form_optional, "(Optional)" %>
 <% content_for :form_description, "You can add some categories to help organize your project. They’ll make it easier to find and classify your project later." %>
 
 <!-- TODO: render form fields for this page -->


### PR DESCRIPTION
I noticed a couple of minor display bugs in the display of "(optional)" in the header in the New Project Request Wizard.  This should fix those.

Screenshot:

<img width="1217" alt="Screenshot 2025-06-25 at 4 08 57 PM" src="https://github.com/user-attachments/assets/6b1ecb20-1a30-455d-91e8-c64c5c609d61" />

