### PR TITLE
Installed Mutex_m in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ group :development, :test do
   gem "ed25519"
   gem "factory_bot_rails", require: false
   gem "ffaker"
+  gem "mutex_m", "~> 0.2.0"
   gem "pry-byebug"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,6 +249,7 @@ GEM
     msgpack (1.7.2)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
+    mutex_m (0.2.0)
     net-http (0.4.1)
       uri
     net-http-persistent (4.0.2)
@@ -547,6 +548,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   mailcatcher
+  mutex_m (~> 0.2.0)
   net-http-persistent
   net-ldap
   omniauth-cas (~> 3.0)


### PR DESCRIPTION
This pr clears a warning message about adding the Mutex_m Gem when we are running tests.
![Screenshot 2025-06-26 at 2 20 24 PM](https://github.com/user-attachments/assets/fa5fc1b1-6ecf-48f5-b816-c6b8526aa2a8)


Co-authored-by: Robert-Anthony Lee-Faison <leefaisonr@users.noreply.github.com>