### PR TITLE
Refactored code that produces the XML representation

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -120,7 +120,6 @@ class ProjectsController < ApplicationController
 
     @project_session = "details"
 
-
     respond_to do |format|
       format.html do
         @project = ProjectShowPresenter.new(project)
@@ -213,10 +212,14 @@ class ProjectsController < ApplicationController
   def show_mediaflux
     project_id = params[:id]
     project = Project.find(project_id)
-
-    respond_to do |format|
-      format.xml do
-        render xml: project.mediaflux_meta_xml
+    if project.mediaflux_id == 0
+      flash[:error] = "Project has not been created in Mediaflux"
+      redirect_to project_path(project_id)
+    else
+      respond_to do |format|
+        format.xml do
+          render xml: project.mediaflux_meta_xml(user: current_user)
+        end
       end
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -197,28 +197,13 @@ class Project < ApplicationRecord
   end
 
   def to_xml
-    ProjectMediaflux.xml_payload(project: self)
-  end
-
-  # @return [Nokogiri::XML::Document] the Mediaflux XML document for this project
-  def mediaflux_document
-    ProjectMediaflux.document(project: self)
-  end
-
-  # @return [Nokogiri::XML::Element] the <meta> element from the Mediaflux XML document
-  def mediaflux_meta_element
-    doc = mediaflux_document.clone
-    # Remove the namespaces in order to simplify the XPath query
-    doc.remove_namespaces!
-    elements = doc.xpath("/request/service/args/meta")
-    raise("Failed to extract the <meta> element found in the Mediaflux XML document for project #{self.id}") if elements.empty?
-
-    elements.first
+    JSON.parse(self.to_json).to_xml
   end
 
   # @return [String] XML representation of the <meta> element
-  def mediaflux_meta_xml
-    mediaflux_meta_element.to_xml
+  def mediaflux_meta_xml(user:)
+    doc = ProjectMediaflux.document(project: self, user: user)
+    doc.xpath("/response/reply/result/asset/meta").to_s
   end
 
   def mediaflux_metadata(session_id:)

--- a/app/models/project_mediaflux.rb
+++ b/app/models/project_mediaflux.rb
@@ -45,24 +45,16 @@ class ProjectMediaflux
     project.save!
   end
 
-  def self.xml_payload(project:, xml_namespace: nil)
-    project_name = project.project_directory
-    project_namespace = "#{project_name}NS"
-    project_parent = Mediaflux::Connection.root_collection
-
-    create_request = Mediaflux::ProjectCreateRequest.new(session_token: nil, namespace: project_namespace, project:, xml_namespace: xml_namespace, pid: project_parent)
-    create_request.xml_payload
+  # Returns the XML string with the mediaflux metadata
+  def self.xml_payload(project:, user:, xml_namespace: nil)
+    request = Mediaflux::AssetMetadataRequest.new(session_token: user.mediaflux_session, id: project.mediaflux_id)
+    request.resolve
+    request.response_body
   end
 
-  def self.document(project:, xml_namespace: nil)
-    xml_body = xml_payload(project:, xml_namespace:)
+  # Returns an XML document with the mediaflux metadata
+  def self.document(project:, user:, xml_namespace: nil)
+    xml_body = xml_payload(project:, user:, xml_namespace:)
     Nokogiri::XML.parse(xml_body)
-  end
-
-  def self.create_root_tree(session_id:)
-    root_ns = Rails.configuration.mediaflux["api_root_collection_namespace"]
-    parent_collection = Rails.configuration.mediaflux["api_root_collection_name"]
-    req = Mediaflux::RootCollectionAsset.new(session_token: session_id, root_ns:, parent_collection:)
-    req.create
   end
 end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -46,41 +46,16 @@ RSpec.describe ProjectsController, type: ["controller", "feature"] do
         end
 
         it "renders the project metadata as xml" do
-          data_sponsor = project.metadata_model.data_sponsor
-          project = FactoryBot.create :project, project_id: "abc-123", data_sponsor: data_sponsor
+          project.approve!(current_user: sponsor_and_data_manager)
           get :details, params: { id: project.id, format: :xml }
           expect(response.content_type).to eq("application/xml; charset=utf-8")
-          expect(response.body).to eq(
-          "<?xml version=\"1.0\"?>\n" \
-          "<request xmlns:tigerdata=\"http://tigerdata.princeton.edu\">\n" \
-          "  <service name=\"asset.create\">\n" \
-          "    <args>\n" \
-          "      <name>#{project.project_directory_short}</name>\n" \
-          "      <namespace>#{project.project_directory}NS</namespace>\n" \
-          "      <meta>\n" \
-          "        <tigerdata:project>\n" \
-          "          <ProjectDirectory>#{project.project_directory}</ProjectDirectory>\n" \
-          "          <Title>#{project.metadata[:title]}</Title>\n" \
-          "          <Description>#{project.metadata[:description]}</Description>\n" \
-          "          <DataSponsor>#{project.metadata[:data_sponsor]}</DataSponsor>\n" \
-          "          <DataManager>#{project.metadata[:data_manager]}</DataManager>\n" \
-          "          <Department>77777</Department>\n" \
-          "          <Department>88888</Department>\n" \
-          "          <DataUser>n/a</DataUser>\n" \
-          "          <ProjectID>abc-123</ProjectID>\n" \
-          "        </tigerdata:project>\n" \
-          "      </meta>\n" \
-          "      <quota>\n" \
-          "        <allocation>500 GB</allocation>\n" \
-          "        <description>Project Quota</description>\n" \
-          "      </quota>\n" \
-          "      <collection cascade-contained-asset-index=\"true\" contained-asset-index=\"true\" unique-name-index=\"true\">true</collection>\n" \
-          "      <type>application/arc-asset-collection</type>\n" \
-          "      <pid>path=/td-test-001/test/tigerdata</pid>\n" \
-          "    </args>\n" \
-          "  </service>\n" \
-          "</request>\n"
-        )
+          xml_doc = Nokogiri::XML(response.body)
+          expect(xml_doc.xpath("/hash/title").text).to eq project.title
+          expect(xml_doc.xpath("/hash/project-directory").text).to eq project.project_directory
+          expect(xml_doc.xpath("/hash/description").text).to eq project.metadata[:description]
+          expect(xml_doc.xpath("/hash/data-sponsor").text).to eq project.metadata[:data_sponsor]
+          expect(xml_doc.xpath("/hash/data-manager").text).to eq project.metadata[:data_manager]
+          expect(xml_doc.xpath("/hash/project-id").text).to eq project.metadata[:project_id]
         end
       end
     end

--- a/spec/mailers/tigerdata_spec.rb
+++ b/spec/mailers/tigerdata_spec.rb
@@ -49,7 +49,10 @@ RSpec.describe TigerdataMailer, type: :mailer do
     expect(mail.attachments.first.mime_type).to eq "application/json"
     # testing the xml response
     expect(mail.attachments.second.filename).to eq "abc123_def.xml"
-    expect(mail.attachments.second.body.raw_source).to eq project.to_xml.gsub("\n", "\r\n")
+    parsed_xml = Nokogiri::XML(mail.attachments.second.body.raw_source)
+    project_xml = Nokogiri::XML(project.to_xml)
+    expect(parsed_xml.xpath("/hash/title").to_s).to eq project_xml.xpath("/hash/title").to_s
+    expect(parsed_xml.xpath("/hash/project-directory").to_s).to eq project_xml.xpath("/hash/project-directory").to_s
     expect(mail.attachments.second.mime_type).to eq "application/xml"
   end
 


### PR DESCRIPTION
Refactored the XML produced when visiting `projects/:id.xml` to not fetch from Mediaflux (since we only need the Ruby data) and the code when visiting `projects/:id/:id-mf.xml` to just fetch the data from Mediaflux (there was a call to create in Mediaflux buried in there.

Closes https://github.com/pulibrary/tigerdata-app/issues/1607

