### PR TITLE
Updated test to use new location of data in Mediaflux

### DIFF
--- a/spec/models/mediaflux/asset_exist_request_headers_spec.rb
+++ b/spec/models/mediaflux/asset_exist_request_headers_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Mediaflux::AssetExistRequest, type: :model, connect_to_mediaflux: true do
   let(:user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
-  let(:namespace_root) { Rails.configuration.mediaflux["api_root_collection_namespace"] }
+  let(:namespace_root) { "princeton/#{Mediaflux::Connection.root}NS" }
 
   context "when we give a user to the class" do
     it "sends the custom HTTP headers to Mediaflux" do


### PR DESCRIPTION
Makes sure the test looks for data in the new location that we use in the Docker container that mimics production