### PR TITLE
Removes project.active code not needed anymore

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -60,25 +60,6 @@ class Project < ApplicationRecord
     self
   end
 
-  def activate!(collection_id:, current_user:)
-    response = Mediaflux::AssetMetadataRequest.new(session_token: current_user.mediaflux_session, id: collection_id)
-    mediaflux_metadata = response.metadata # get the metadata of the collection from mediaflux
-
-    return unless mediaflux_metadata[:collection] == true # If the collection id exists
-
-    # check if the project doi in rails matches the project doi in mediaflux
-    return unless mediaflux_metadata[:project_id] == self.metadata_model.project_id
-
-    # activate a project by setting the status to 'active'
-    self.metadata_model.status = Project::ACTIVE_STATUS
-
-    # also read in the actual project directory
-    self.metadata_model.project_directory = mediaflux_metadata[:project_directory]
-    self.save!
-
-    ProvenanceEvent.generate_active_events(project: self, user: current_user)
-  end
-
   def draft_doi(user: nil)
     puldatacite = PULDatacite.new
     self.metadata_model.project_id = puldatacite.draft_doi

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -331,47 +331,6 @@ RSpec.describe Project, type: :model, connect_to_mediaflux: true do
       expect(debug_event.event_details).to eq "Debug output"
     end
   end
-
-  describe "#activate!",
-  :integration do
-  let(:project) { FactoryBot.create(:project_with_dynamic_directory, project_id: "10.34770/tbd")}
-  let(:current_user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
-  let(:project_metadata) {project.metadata_model}
-  after do
-    Mediaflux::AssetDestroyRequest.new(session_token: current_user.mediaflux_session, collection: project.mediaflux_id, members: true).resolve
-  end
-  it "activates a project" do
-    project.create!(initial_metadata: project.metadata_model, user: current_user)
-
-    # create a project in mediaflux
-    project.approve!(current_user: current_user)
-
-    #validate that the collection id exists in mediaflux
-    project.activate!(collection_id: project.mediaflux_id, current_user:)
-    expect(project.mediaflux_id).to eq(project.mediaflux_id)
-    expect(project.metadata_model.status).to eq Project::ACTIVE_STATUS
-
-    #activate the project by setting the status to active and creating the necessary provenance events
-    activate_event = project.provenance_events.select { |event| event.event_type == ProvenanceEvent::ACTIVE_EVENT_TYPE}.first  #testing the approval Event
-    expect(activate_event.event_type).to eq ProvenanceEvent::ACTIVE_EVENT_TYPE
-    expect(activate_event.event_person).to eq current_user.uid
-    expect(activate_event.event_details).to eq "Activated by Tigerdata Staff"
-  end
-
-  it "tries to activate a project that has a mismatched doi" do
-      project.create!(initial_metadata: project.metadata_model, user: current_user)
-
-      # create a project in mediaflux
-      project.approve!(current_user: current_user)
-
-      # change the doi so it will not match up when activated
-      project.metadata_model.project_id = "90.34770/xyz"
-      project.save!
-
-      #validate that the collection id exists in mediaflux
-      project.activate!(collection_id: project.mediaflux_id, current_user:)
-      expect(project.metadata_model.status).to_not eq Project::ACTIVE_STATUS
-  end
 end
 
   describe ".default_storage_unit" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -331,7 +331,6 @@ RSpec.describe Project, type: :model, connect_to_mediaflux: true do
       expect(debug_event.event_details).to eq "Debug output"
     end
   end
-end
 
   describe ".default_storage_unit" do
     it "returns the default storage unit of KB" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -256,14 +256,14 @@ RSpec.describe Project, type: :model, connect_to_mediaflux: true do
       end
 
       it "does not mint a new DOI when the project has a project_id" do
-        project.metadata_model.update_with_params({"project_id" => "123"},  current_user)
+        project.metadata_model.update_with_params({ "project_id" => "123" }, current_user)
         doi = project.create!(initial_metadata: project.metadata_model, user: current_user)
         expect(datacite_stub).to_not have_received(:draft_doi)
         expect(doi).to eq "123"
       end
 
       it "mints a DOI when needed" do
-        project.metadata_model.update_with_params({"project_id" => ProjectMetadata::DOI_NOT_MINTED},  current_user)
+        project.metadata_model.update_with_params({ "project_id" => ProjectMetadata::DOI_NOT_MINTED }, current_user)
         project.create!(initial_metadata: project.metadata_model, user: current_user)
         expect(datacite_stub).to have_received(:draft_doi)
       end
@@ -271,16 +271,18 @@ RSpec.describe Project, type: :model, connect_to_mediaflux: true do
 
     context "Provenance events" do
       it "creates the provenance events when creating a new project" do
-        project.metadata_model.update_with_params({"project_id" => ProjectMetadata::DOI_NOT_MINTED},  current_user)
+        project.metadata_model.update_with_params({ "project_id" => ProjectMetadata::DOI_NOT_MINTED }, current_user)
         project.create!(initial_metadata: project.metadata_model, user: current_user)
 
         expect(project.provenance_events.count).to eq 2
-        submission_event = project.provenance_events.first #testing the Submission Event
+        submission_event = project.provenance_events.first # testing the Submission Event
         expect(submission_event.event_type).to eq ProvenanceEvent::SUBMISSION_EVENT_TYPE
         expect(submission_event.event_person).to eq current_user.uid
         expect(submission_event.event_details).to eq "Requested by #{current_user.display_name_safe}"
 
-        status_update_event = project.provenance_events.last #testing the Status Update Event when the project is first submitted, #TODO: will need a separate test for when a project is approved by an admin
+        # testing the Status Update Event when the project is first submitted,
+        # TODO: will need a separate test for when a project is approved by an admin
+        status_update_event = project.provenance_events.last
         expect(status_update_event.event_type).to eq ProvenanceEvent::STATUS_UPDATE_EVENT_TYPE
         expect(status_update_event.event_person).to eq current_user.uid
         expect(status_update_event.event_details).to eq "The Status of this project has been set to pending"
@@ -299,7 +301,7 @@ RSpec.describe Project, type: :model, connect_to_mediaflux: true do
 
     it "Records the mediaflux id and sets the status to approved",
     :integration do
-      project.metadata_model.update_with_params({"project_id" => "123"},  current_user)
+      project.metadata_model.update_with_params({ "project_id" => "123" }, current_user)
       project.create!(initial_metadata: project.metadata_model, user: current_user)
 
       project.approve!(current_user: current_user)
@@ -311,7 +313,7 @@ RSpec.describe Project, type: :model, connect_to_mediaflux: true do
 
     it "creates the provenance events when creating a new project",
     :integration do
-      project.metadata_model.update_with_params({"project_id" => ProjectMetadata::DOI_NOT_MINTED}, current_user)
+      project.metadata_model.update_with_params({ "project_id" => ProjectMetadata::DOI_NOT_MINTED }, current_user)
       project.create!(initial_metadata: project.metadata_model, user: current_user)
       project.approve!(current_user: current_user)
       project.reload
@@ -320,13 +322,13 @@ RSpec.describe Project, type: :model, connect_to_mediaflux: true do
       expect(project.metadata_model.status).to eq Project::APPROVED_STATUS
 
       expect(project.provenance_events.count).to eq 5
-      approval_event = project.provenance_events.select { |event| event.event_type == ProvenanceEvent::APPROVAL_EVENT_TYPE}.first
+      approval_event = project.provenance_events.find { |event| event.event_type == ProvenanceEvent::APPROVAL_EVENT_TYPE }
 
       expect(approval_event.event_type).to eq ProvenanceEvent::APPROVAL_EVENT_TYPE
       expect(approval_event.event_person).to eq current_user.uid
       expect(approval_event.event_details).to eq "Approved by #{current_user.display_name_safe}"
 
-      debug_event = project.provenance_events.select { |event| event.event_type == ProvenanceEvent::DEBUG_OUTPUT_TYPE}.first
+      debug_event = project.provenance_events.find { |event| event.event_type == ProvenanceEvent::DEBUG_OUTPUT_TYPE }
       expect(debug_event.event_person).to eq current_user.uid
       expect(debug_event.event_details).to eq "Debug output"
     end


### PR DESCRIPTION
Removes the `project.activate!` code since it is not needed anymore. 

Most of this code was removed with https://github.com/pulibrary/tigerdata-app/pull/1651 but evidently we had a few remnants 