### PR TITLE
1693 vertical scroll

### DIFF
--- a/app/assets/stylesheets/_wizard.scss
+++ b/app/assets/stylesheets/_wizard.scss
@@ -119,7 +119,7 @@
           align-self: stretch;
           overflow-y: scroll;
           scrollbar-width: thin;
-          scrollbar-color: $princeton-orange-80 $gray-20;
+          scrollbar-color: $princeton-orange-80 $gray-5;
 
           .form-field {
             display: flex;

--- a/app/assets/stylesheets/_wizard.scss
+++ b/app/assets/stylesheets/_wizard.scss
@@ -118,6 +118,8 @@
           gap: 2.5rem;
           align-self: stretch;
           overflow-y: scroll;
+          scrollbar-width: thin;
+          scrollbar-color: $princeton-orange-80 $gray-20;
 
           .form-field {
             display: flex;


### PR DESCRIPTION
Could optionally enhance #1693 

The issue indicated in the ticket does not appear to be an issue.  In Chuck's recording and in the browser, the vertical scrollbar is always visible (this is controlled via the "overflow-y: scroll" value in the CSS).

Here is how it currently looks in Firefox (same results in Vivaldi as well):
<img width="1339" height="847" alt="Screenshot 2025-08-07 at 11 14 10 AM" src="https://github.com/user-attachments/assets/89e95391-5314-4609-92b8-b9f5453512f6" />

I've added some color to the scrollbar if we want to do that, but it deviates from Figma and I'm not sure if it's desired:
<img width="1293" height="836" alt="Screenshot 2025-08-07 at 11 15 00 AM" src="https://github.com/user-attachments/assets/7d88820b-3894-4c30-913c-f63017eb2216" />

I'm going to close the original ticket.  This PR can go in or not depending on preference.

