### PR TITLE
Declare the project defaults for the CI environment.

### DIFF
--- a/config/project.yml
+++ b/config/project.yml
@@ -14,6 +14,8 @@ qa:
   <<: *default
 staging:
   <<: *default
+ci:
+  <<: *default
 development:
   <<: *default
 test:


### PR DESCRIPTION
This is needed so that the Project Creation can set the proper defaults.

We ran into this while troubleshooting https://github.com/pulibrary/tigerdata-app/issues/1691