### PR TITLE
Force a valid DOI prefix

### DIFF
--- a/config/datacite.yml
+++ b/config/datacite.yml
@@ -7,6 +7,7 @@ default: &default
   doi_url: "https://handle.stage.datacite.org/"
 production:
   <<: *default
+  prefix: "10.60803"
   # Use the TigerData specific settings
   doi_url: "https://doi.org/"
 qa:


### PR DESCRIPTION
Fixes the DOI prefix so that we can approve projects all the way. If this work we should make the change in Ansible.

Part of #1717

