### PR TITLE
Remove extra logic that is not longer needed when creating new projects in Mediaflux

### DIFF
--- a/app/models/mediaflux/project_create_service_request.rb
+++ b/app/models/mediaflux/project_create_service_request.rb
@@ -19,9 +19,6 @@ module Mediaflux
       @project_id = @project.metadata_model.project_id
       @department = departments_string(@project.metadata_model.departments)
       @quota = "#{@project.metadata_model.storage_capacity['size']['approved']} #{@project.metadata_model.storage_capacity['unit']['approved']}"
-      # We set the datastore to "db" because the default is a store that
-      # only exists in the production Mediaflux.
-      @store = "db" unless Rails.env.production?
     end
 
     # Specifies the Mediaflux service to use when creating project
@@ -59,7 +56,6 @@ module Mediaflux
       #   :directory tigerdata/RC/td-testing/md1908/HectorProject2 \
       #   :project-id "fake.id" \
       #   :quota "10 TB" \
-      #   :store db \
       #   :title "Fake Study"
       #
       def build_http_request_body(name:)
@@ -78,9 +74,6 @@ module Mediaflux
               xml.text(@project_id)
             end
             xml.quota @quota
-            unless Rails.env.production?
-              xml.store @store
-            end
             xml.title @title
           end
         end


### PR DESCRIPTION
Remove extra logic that is not longer needed when creating a new project via the tigerdata.project.create. 

The logic is not longer needed now that the Docker container has the correct defaults.

Closes #1724 
