### PR TITLE
Removes tab not longer needed from the page

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -5,11 +5,6 @@
     <div id="project-nav">
       <button id="project-content" class="tab-nav"> Content Preview </button>
       <button id="project-details" class="tab-nav"> Details </button>
-      <% if current_user.eligible_sysadmin? %>
-        <% if @project.pending? %>
-          <button id="project-approval" class="tab-nav"> Approval Setting </button>
-          <% end %>
-      <% end %>
     </div>
     <div class="row align-items-center contents-summary">
       <div class="col-sm-2 file-inventory">File Inventory:</div>


### PR DESCRIPTION
This was a left over from when we show approval settings on the Project Show page.