### PR TITLE
Display the user's authentication provider on the User Show page

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,5 +8,9 @@
 <p>Super User? <%= @user.superuser %></p>
 <p>System Administrator? <%= @user.sysadmin %></p>
 <p>Trainer: <%= @user.trainer %></p>
-
+<% if @user.provider.blank? %>
+    <p>Provider: not set (User will not be able to authenticate via CAS)</p>
+<% else %>
+    <p>Provider: <%= @user.provider %></p>
+<% end %>
 <button><%= link_to("Edit", edit_user_path(@user)) %></button>

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -8,6 +8,7 @@ describe "Current Users page", type: :system, connect_to_mediaflux: false, js: t
   let(:sysadmin_user) { FactoryBot.create(:sysadmin, uid: "puladmin", mediaflux_session: SystemUser.mediaflux_session) }
   let(:superuser) { FactoryBot.create(:superuser, uid: "root", mediaflux_session: SystemUser.mediaflux_session) }
   let!(:data_manager) { FactoryBot.create(:data_manager, uid: "pul987", mediaflux_session: SystemUser.mediaflux_session) }
+  let(:user_without_provider) { FactoryBot.create(:data_manager, provider: "", mediaflux_session: SystemUser.mediaflux_session) }
 
   context "unauthenticated user" do
     it "shows the 'Log In' button" do
@@ -78,7 +79,14 @@ describe "Current Users page", type: :system, connect_to_mediaflux: false, js: t
       sign_in sysadmin_user
       visit "/users/#{data_manager.id}"
       expect(page).to have_content "NetID: #{data_manager.uid}"
+      expect(page).to have_content "Provider: cas"
       expect(page).to have_button "Edit"
+    end
+
+    it "warns if the authentication provider is not set" do
+      sign_in sysadmin_user
+      visit "/users/#{user_without_provider.id}"
+      expect(page).to have_content "Provider: not set"
     end
 
     it "allows user to edit information" do


### PR DESCRIPTION
Makes it obvious when a user's authentication provider has not been set since that's important to us when troubleshooting authentication errors.

