### PR TITLE
Log authentication errors

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -7,9 +7,11 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     set_cas_session
 
     if @user.nil? && access_token&.provider == "cas"
+      Rails.logger.warn "User from CAS with netid #{access_token&.uid} was not found. Provider: cas"
       redirect_to help_path
       flash.notice = "You can not be signed in at this time."
     elsif @user.nil?
+      Rails.logger.warn "User from CAS with netid #{access_token&.uid} was not found. Provider: #{access_token&.provider}"
       redirect_to root_path
       flash.alert = "You are not a recognized CAS user."
     else

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Users::OmniauthCallbacksController do
     end
   end
 
-  context "uknown user" do
+  context "unknown user" do
     it "redirects to the help page with alert" do
-      controller.request.env["omniauth.auth"] = double(OmniAuth::AuthHash, provider: "cas")
+      controller.request.env["omniauth.auth"] = double(OmniAuth::AuthHash, provider: "cas", uid: nil)
       allow(User).to receive(:from_cas) { nil }
       get :cas
       expect(response).to redirect_to(help_path)
@@ -25,7 +25,7 @@ RSpec.describe Users::OmniauthCallbacksController do
 
   context "non-CAS user" do
     it "redirects to the home page with alert" do
-      controller.request.env["omniauth.auth"] = double(OmniAuth::AuthHash, provider: "other")
+      controller.request.env["omniauth.auth"] = double(OmniAuth::AuthHash, provider: "other", uid: nil)
       allow(User).to receive(:from_cas) { nil }
       get :cas
       expect(response).to redirect_to(root_path)


### PR DESCRIPTION
Log authentication errors to the Rails log. 

I am not pushing these errors to Honeybadger because that might be too noisy, but it would be good to have some trace of them when we are troubleshooting. Currently there is nothing on the Rails logs which is confusing because users do get an error on the web page but we have not record of it. 