### PR TITLE
Better handling for Mediaflux XML error responses

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -152,6 +152,10 @@ class ProjectsController < ApplicationController
         end
       end
     end
+  rescue => ex
+    Rails.logger.error "Error getting MediaFlux XML for project #{project_id}, user #{current_user.uid}: #{ex.message}"
+    flash[:alert] = "Error fetching Mediaflux XML for this project"
+    redirect_to project_path(project_id)
   end
 
   def project_job_service

--- a/app/models/project_mediaflux.rb
+++ b/app/models/project_mediaflux.rb
@@ -10,6 +10,9 @@ class ProjectMediaflux
   def self.xml_payload(project:, user:, xml_namespace: nil)
     request = Mediaflux::AssetMetadataRequest.new(session_token: user.mediaflux_session, id: project.mediaflux_id)
     request.resolve
+    if request.error?
+      raise request.response_error[:message]
+    end
     request.response_body
   end
 

--- a/spec/models/project_mediaflux_spec.rb
+++ b/spec/models/project_mediaflux_spec.rb
@@ -96,4 +96,11 @@ RSpec.describe ProjectMediaflux, type: :model do
       expect(project.metadata_model.updated_by).to eq "user123"
     end
   end
+
+  describe "#xml_payload" do
+    it "raises errors when project is not accessible", :integration do
+      # The project is not in mediaflux and therefore this will raise an exception
+      expect { described_class.xml_payload(project: project, user: current_user) }.to raise_error(StandardError)
+    end
+  end
 end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -165,13 +165,13 @@ RSpec.describe "/projects", connect_to_mediaflux: true, type: :request do
         sign_in data_manager
       end
 
-      it "provides the xml metadata for a project" do
+      it "provides the xml metadata for a project", :integration do
         get project_show_mediaflux_url(project), params: { format: :xml }
         expect(response.code).to eq "200"
         expect(response.content_type).to match "xml"
       end
 
-      it "redirect to the project page when there is an error" do
+      it "redirect to the project page when there is an error", :integration do
         # Go to a non-existing project to force an error
         get project_show_mediaflux_url("non-existing"), params: { format: :xml }
         expect(response.code).to eq "302"

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -156,19 +156,25 @@ RSpec.describe "/projects", connect_to_mediaflux: true, type: :request do
   end
 
   describe "GET /projects/:id/:id-mf" do
-    let(:data_manager) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
+    let(:data_manager) { FactoryBot.create(:user, uid: "hc8719", mediaflux_session: SystemUser.mediaflux_session) }
     let(:project) { FactoryBot.create(:approved_project, data_manager: data_manager.uid) }
 
     context "when the user is authenticated" do
       before do
+        project.approve!(current_user: sponsor_and_data_manager_user)
         sign_in data_manager
       end
 
       it "provides the xml metadata for a project" do
-        # project/12.xml
         get project_show_mediaflux_url(project), params: { format: :xml }
         expect(response.code).to eq "200"
         expect(response.content_type).to match "xml"
+      end
+
+      it "redirect to the project page when there is an error" do
+        # Go to a non-existing project to force an error
+        get project_show_mediaflux_url("non-existing"), params: { format: :xml }
+        expect(response.code).to eq "302"
       end
     end
   end


### PR DESCRIPTION
Show an error message to the user (via flash banner) when we cannot fetch the XML from Mediaflux rather than returning an invalid XML that the browser does not know how to handle.

Closes #1753 
