### PR TITLE
Proof of concept to see if Nokogiri accepts XSD asserts

### DIFF
--- a/lib/assets/assert-invalid.xml
+++ b/lib/assets/assert-invalid.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<!-- example from https://mukulgandhi.blogspot.com/2020/02/xml-schema-11-use-cases-with-and.html -->
+<X>
+    <w>some string</w>
+</X>

--- a/lib/assets/assert-valid.xml
+++ b/lib/assets/assert-valid.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<!-- example from https://mukulgandhi.blogspot.com/2020/02/xml-schema-11-use-cases-with-and.html -->
+<X>
+    <b>some string</b>
+</X>

--- a/lib/assets/assert.xsd
+++ b/lib/assets/assert.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!-- example from https://mukulgandhi.blogspot.com/2020/02/xml-schema-11-use-cases-with-and.html -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="X">
+       <xs:complexType>
+          <xs:choice>
+             <xs:element name="a" type="xs:string"/>
+             <xs:element name="b" type="xs:string"/>
+             <xs:element name="c" type="xs:string"/>
+          </xs:choice>
+       </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/lib/tasks/xml_schema.rake
+++ b/lib/tasks/xml_schema.rake
@@ -22,6 +22,7 @@ namespace :xml_schema do
     if errors.count == 0
       puts "OK! - XML example #{document_file} validates against schema #{schema_file}"
     else
+      puts "Invalid - XML example #{document_file} is not valid against schema #{schema_file}"
       errors.each do |error|
         puts error.message
       end
@@ -35,7 +36,7 @@ namespace :xml_schema do
   # For more information see: https://stackoverflow.com/a/18527198/446681
   def use_local_xml_xsd(xsd)
     local_xml_xsd = Pathname.new("./lib/assets/xml.xsd").realpath.to_s
-    xsd.sub!("https://www.w3.org/2001/xml.xsd", "file://#{local_xml_xsd}")
+    xsd.sub("https://www.w3.org/2001/xml.xsd", "file://#{local_xml_xsd}")
   end
 end
 # :nocov:


### PR DESCRIPTION
This is a proof of concept to see if Nokogiri support XSD assertions. The good news is that it does. 

File `lib/assets/assert.xsd` is a small XSD that has a simple assertion test. 

Files `lib/assets/assert-invalid.xml` and `lib/assets/assert-valid.xml` are two small XML documents that test the assertion in the XSD to show that it detects invalid documents and valid documents.

This is the output that the validation show in each case:

```
$ bundle exec rake xml_schema:validate_example[lib/assets/assert.xsd,lib/assets/assert-valid.xml]
OK! - XML example lib/assets/assert-valid.xml validates against schema lib/assets/assert.xsd
```

```
bundle exec rake xml_schema:validate_example[lib/assets/assert.xsd,lib/assets/assert-invalid.xml]
Invalid - XML example lib/assets/assert-invalid.xml is not valid against schema lib/assets/assert.xsd
4:0: ERROR: Element 'w': This element is not expected. Expected is one of ( a, b, c ).
```