### PR TITLE
Sets a user sys admin status based on group information

### DIFF
--- a/app/controllers/mediaflux_info_controller.rb
+++ b/app/controllers/mediaflux_info_controller.rb
@@ -4,7 +4,9 @@ class MediafluxInfoController < ApplicationController
   def index
     version_request = Mediaflux::VersionRequest.new(session_token: current_user.mediaflux_session)
     @mf_version = version_request.version
-    @current_user_mediaflux_roles = current_user.current_user_mediaflux_roles(session_token: current_user.mediaflux_session)
+    @mediaflux_roles = User.mediaflux_roles(user: current_user)
+    @sysadmin = current_user.sysadmin
+    @developer = current_user.developer
     respond_to do |format|
       format.html
       format.json { render json: @mf_version }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,7 +70,7 @@ class User < ApplicationRecord
     session[:active_web_user] = @active_web_user
     logger.debug "Login Session #{session[:mediaflux_session]} cas: #{session[:active_web_user]}  user: #{uid}"
 
-    update_current_user_status(session_token: @mediaflux_session)
+    User.update_user_roles(user: self)
   end
 
   def terminate_mediaflux_session
@@ -163,28 +163,31 @@ class User < ApplicationRecord
     @latest_downloads ||= UserRequest.where(user_id: id).where(["completion_time > ?", 7.days.ago]).order(created_at: "DESC").limit(limit)
   end
 
-  # Updates the current user's status (sysadmin, developer) based on the information in
-  # Mediaflux for the current session.
-  # This method is meant to be used only for the current_user, hence the name.
-  def update_current_user_status(session_token:)
-    mediaflux_roles = current_user_mediaflux_roles(session_token:)
-    update_current_user_developer_status(mediaflux_roles:)
-    update_current_user_sysadmin_status(mediaflux_roles:)
+  # Updates the user's roles (sys admin, developer) depending on the information on Mediaflux.
+  # This method is meant to be used only for the current logged in user since the roles depend on the Mediaflux session.
+  def self.update_user_roles(user:)
+    raise "User.update_user_roles called with for a user without a Mediaflux session" if user.mediaflux_session.nil?
+
+    mediaflux_roles = mediaflux_roles(user:)
+    update_developer_status(user:, mediaflux_roles:)
+    update_sysadmin_status(user:, mediaflux_roles:)
   rescue => ex
-    Rails.logger.error("Error updating user (id: #{self.id}) status, error: #{ex.message}")
+    Rails.logger.error("Error updating roles for user (id: #{user.id}) status, error: #{ex.message}")
   end
 
   # Returns the roles in Mediaflux for the user in the session.
-  # This is meant to be used only for the current_user, hence the name.
-  def current_user_mediaflux_roles(session_token:)
-    request = Mediaflux::ActorSelfDescribeRequest.new(session_token:)
+  # This method is meant to be used only for the current logged in user since the roles depend on the Mediaflux session.
+  def self.mediaflux_roles(user:)
+    raise "User.mediaflux_roles called with for a user without a Mediaflux session" if user.mediaflux_session.nil?
+
+    request = Mediaflux::ActorSelfDescribeRequest.new(session_token: user.mediaflux_session)
     request.resolve
     request.roles
   end
 
   private
 
-  def update_current_user_developer_status(mediaflux_roles:)
+  def self.update_developer_status(user:, mediaflux_roles:)
     # TODO: Figure out why the role name is different in staging from production:
     #   production:   "pu-smb-group:PU:tigerdata:librarydevelopers"
     #   staging:      "pu-oit-group:PU:tigerdata:librarydevelopers"
@@ -194,21 +197,21 @@ class User < ApplicationRecord
       mediaflux_roles.include?("pu-oit-group:PU:tigerdata:librarydevelopers") ||
       mediaflux_roles.include?("pu-lib:developer") ||
       mediaflux_roles.include?("system-administrator")
-    if developer != developer_now
+    if user.developer != developer_now
       # Only update the record in the database if there is a change
-      Rails.logger.info("Updating developer role for user #{self.id} to #{developer_now}")
-      self.developer = developer_now
-      save!
+      Rails.logger.info("Updating developer role for user #{user.id} to #{developer_now}")
+      user.developer = developer_now
+      user.save!
     end
   end
 
-  def update_current_user_sysadmin_status(mediaflux_roles:)
+  def self.update_sysadmin_status(user:, mediaflux_roles:)
     sysadmin_now = mediaflux_roles.include?("system-administrator")
-    if sysadmin != sysadmin_now
+    if user.sysadmin != sysadmin_now
       # Only update the record in the database if there is a change
-      Rails.logger.info("Updating sysadmin role for user #{self.id} to #{sysadmin_now}")
-      self.sysadmin = sysadmin_now
-      save!
+      Rails.logger.info("Updating sysadmin role for user #{user.id} to #{sysadmin_now}")
+      user.sysadmin = sysadmin_now
+      user.save!
     end
   end
 end

--- a/app/views/mediaflux_info/index.html.erb
+++ b/app/views/mediaflux_info/index.html.erb
@@ -3,6 +3,12 @@
   <dt>Mediaflux Port: </dt>
   <dd><%= Mediaflux::Connection.port %></dd>
 
+  <dt>Sys Admin:</dt>
+  <dd><%= current_user.sysadmin %></dd>
+
+  <dt>Developer:</dt>
+  <dd><%= current_user.developer %></dd>
+
   <% if @current_user_mediaflux_roles.count > 0 %>
     <dt>Mediaflux Roles:</dt>
     <dd>

--- a/app/views/mediaflux_info/index.html.erb
+++ b/app/views/mediaflux_info/index.html.erb
@@ -4,16 +4,16 @@
   <dd><%= Mediaflux::Connection.port %></dd>
 
   <dt>Sys Admin:</dt>
-  <dd><%= current_user.sysadmin %></dd>
+  <dd><%= @sysadmin %></dd>
 
   <dt>Developer:</dt>
-  <dd><%= current_user.developer %></dd>
+  <dd><%= @developer %></dd>
 
-  <% if @current_user_mediaflux_roles.count > 0 %>
+  <% if @mediaflux_roles.count > 0 %>
     <dt>Mediaflux Roles:</dt>
     <dd>
       <ul>
-        <% @current_user_mediaflux_roles.each do |role| %>
+        <% @mediaflux_roles.each do |role| %>
           <li><%= role %>
         <% end %>
       <ul>

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -107,7 +107,7 @@ describe "Current Users page", type: :system, connect_to_mediaflux: false, js: t
     end
   end
 
-  describe "user#update_current_user_status" do
+  describe "user#update_user_roles" do
     before do
       sysadmin_user.developer = false
       sysadmin_user.sysadmin = false
@@ -118,7 +118,7 @@ describe "Current Users page", type: :system, connect_to_mediaflux: false, js: t
       expect(sysadmin_user.sysadmin).to be false
       expect(sysadmin_user.developer).to be false
       sign_in sysadmin_user
-      sysadmin_user.update_current_user_status(session_token: sysadmin_user.mediaflux_session)
+      User.update_user_roles(user: sysadmin_user)
       expect(sysadmin_user.sysadmin).to be true
       expect(sysadmin_user.developer).to be true
     end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -107,16 +107,19 @@ describe "Current Users page", type: :system, connect_to_mediaflux: false, js: t
     end
   end
 
-  describe "user#check_if_current_user_is_developer" do
+  describe "user#update_current_user_status" do
     before do
       sysadmin_user.developer = false
+      sysadmin_user.sysadmin = false
       sysadmin_user.save!
     end
 
-    it "mark as developer an admin user" do
+    it "mark as developer an admin and a developer user" do
+      expect(sysadmin_user.sysadmin).to be false
       expect(sysadmin_user.developer).to be false
       sign_in sysadmin_user
-      sysadmin_user.check_if_current_user_is_developer(session_token: sysadmin_user.mediaflux_session)
+      sysadmin_user.update_current_user_status(session_token: sysadmin_user.mediaflux_session)
+      expect(sysadmin_user.sysadmin).to be true
       expect(sysadmin_user.developer).to be true
     end
   end

--- a/spec/views/mediaflux_infos/index.html.erb_spec.rb
+++ b/spec/views/mediaflux_infos/index.html.erb_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 RSpec.describe "mediaflux_info/index", type: :view do
   before(:each) do
     assign(:mf_version, { version: "1001" })
-    assign(:current_user_mediaflux_roles, ["role1", "role2"])
+    assign(:mediaflux_roles, ["role1", "role2"])
   end
 
   it "renders a mediaflux information" do


### PR DESCRIPTION
Sets the user "sysadmin" status based on the roles reported for the user in Mediaflux (we are using the groups fetched by Mediaflux from LDAP). If the user has the correct role in Mediaflux then we assume the user is a sysadmin, similar to the work on PR #1825 for developer status.