### PR TITLE
Fixes bug when there is a field without a Mediaflux label

### DIFF
--- a/app/models/mediaflux/schema_fetch_request.rb
+++ b/app/models/mediaflux/schema_fetch_request.rb
@@ -35,7 +35,7 @@ module Mediaflux
           type: element.attributes["type"].value,
           index: element.attributes["index"]&.value == "true",
           "min-occurs" => 1,
-          label: element.attributes["label"].value,
+          label: element.attributes["label"]&.value || element.attributes["name"].value,
           description: element.xpath("description").text,
           instructions: element.xpath("instructions").text
         }

--- a/spec/models/mediaflux/schema_fetch_request_spec.rb
+++ b/spec/models/mediaflux/schema_fetch_request_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Mediaflux::SchemaFetchRequest, connect_to_mediaflux: true, type: :model, integration: true do
+  let(:namespace) { "tigerdata" }
+  let(:type) { "tigerdata:project" }
+  let(:session_token) { Mediaflux::LogonRequest.new.session_token }
+  let(:field_without_label) do
+    xml = '<element name="ProjectPurpose" type="string" min-occurs="0" max-occurs="1"><description>The high-level category for the purpose of the project</description></element>'
+    doc = Nokogiri(xml)
+    doc.children.first
+  end
+
+  describe "#field_from_element" do
+    it "handles fields without a label gracefully" do
+      request = described_class.new(session_token: session_token, namespace: namespace, type: type)
+      field = request.send( :field_from_element, field_without_label)
+      expect(field[:label]).to eq field[:name]
+    end
+  end
+end


### PR DESCRIPTION
With the [introduction of the new fields](https://github.com/PrincetonUniversityLibrary/tigerdata-config/pull/223) (Project Purpose, HPC, SMB, Globus) we discovered that the frontend is not handling gracefully when a field is defined in Mediaflux without a label. 

In particular the Project Purpose field does not have a label and it was crashing the project creation process. This PR fixes that bug.

