### PR TITLE
Create Space Ghost system spec and allow users to see project request wizard link

### DIFF
--- a/spec/system/space_ghost_spec.rb
+++ b/spec/system/space_ghost_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "open-uri"
+
+RSpec.describe "The Space Ghost Epic", connect_to_mediaflux: true, js: true, integration: true do
+  context "user" do
+    let(:user) { FactoryBot.create(:user, uid: "pul123", mediaflux_session: SystemUser.mediaflux_session) }
+    it "displays the new project wizard on the dashboard" do
+      test_strategy = Flipflop::FeatureSet.current.test!
+      test_strategy.switch!(:allow_all_users_wizard_access, true)
+      sign_in user
+      visit "/"
+      expect(page).to have_content("Welcome, #{user.given_name}!")
+      byebug
+    end
+  end
+end

--- a/spec/system/space_ghost_spec.rb
+++ b/spec/system/space_ghost_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "The Space Ghost Epic", connect_to_mediaflux: true, js: true, int
       sign_in user
       visit "/"
       expect(page).to have_content("Welcome, #{user.given_name}!")
+      test_strategy.switch!(:allow_all_users_wizard_access, false)
     end
   end
 end

--- a/spec/system/space_ghost_spec.rb
+++ b/spec/system/space_ghost_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe "The Space Ghost Epic", connect_to_mediaflux: true, js: true, int
       sign_in user
       visit "/"
       expect(page).to have_content("Welcome, #{user.given_name}!")
-      byebug
     end
   end
 end


### PR DESCRIPTION
Created a Space Ghost system spec and tested that a user can see the project request wizard button

Co-authored-by: Bess Sadler <bess@users.noreply.github.com>
Co-authored-by: Robert-Anthony Lee-Faison <leefaisonr@users.noreply.github.com>