### PR TITLE
Add HTML and CSS formatting and style to Storage and Access options to match Figma

### DIFF
--- a/app/assets/stylesheets/_wizard.scss
+++ b/app/assets/stylesheets/_wizard.scss
@@ -584,6 +584,157 @@
           align-self: stretch;
         }
       }
+
+      .form-field-label-vertical-container {
+        width: 183px; 
+        flex-direction: column; 
+        justify-content: flex-start; 
+        align-items: flex-start; 
+        display: inline-flex;
+      }
+
+      .form-field-label-vertical-text {
+        align-self: stretch; 
+        justify-content: center; 
+        display: flex; 
+        flex-direction: column; 
+        color: $black; 
+        font-size: 18px; 
+        font-family: $libre-franklin; 
+        font-weight: 600; 
+        line-height: 27px; 
+        word-wrap: break-word;
+      }
+
+      .form-field-element-vertical-container {
+        flex-direction: column;
+        justify-content: flex-start; 
+        align-items: flex-start; 
+        gap: 8px; 
+        display: inline-flex;
+      }
+
+      .estimated-files-dropdown {
+        align-self: stretch; 
+        flex-direction: column; 
+        justify-content: flex-start; 
+        align-items: flex-start; 
+        gap: 10px; 
+        display: flex;
+      }
+
+      .estimated-files-dropdown-subcontainer {
+        align-self: stretch; 
+        flex-direction: column; 
+        justify-content: flex-start; 
+        align-items: flex-start; 
+        gap: 4px; 
+        display: flex;
+      }
+
+      .estimated-files-inline-subcontainer {
+        align-self: stretch; 
+        padding-left: 12px; 
+        padding-right: 12px; 
+        padding-top: 8px; 
+        padding-bottom: 8px; 
+        background: var(--Neutral-White, white); 
+        border-radius: 8px; 
+        outline: 1px var(--Neutral-Medium-Gray, #D0D0D0) solid; 
+        outline-offset: -1px; 
+        justify-content: space-between; 
+        align-items: center; 
+        display: inline-flex;
+      }
+
+      .storage-form-field-text {
+        color: $black; 
+        font-size: 16px; 
+        font-family: $libre-franklin; 
+        font-weight: 400; 
+        line-height: 24px; 
+        word-wrap: break-word;
+      }
+
+      .storage-tooltip {
+        width: 100%; 
+        color: $gray-60; 
+        font-size: 14px; 
+        font-family: $libre-franklin; 
+        font-weight: 400; 
+        line-height: 21px; 
+        word-wrap: break-word;
+      }
+
+      .connection-options-text-container {
+        flex: 1 1 0; 
+        overflow: hidden; 
+        flex-direction: column; 
+        justify-content: flex-start; 
+        align-items: flex-start; 
+        gap: 4px; 
+        display: inline-flex;
+      }
+      
+      .connection-options-text {
+        justify-content: center; 
+        display: flex; 
+        flex-direction: column; 
+        color: var(--Neutral-Black, #121212); 
+        font-size: 16px; 
+        font-family: Libre Franklin; 
+        font-weight: 600; 
+        line-height: 24px; 
+        word-wrap: break-word;
+      }
+
+      .connection-options-radio-buttons-container {
+        overflow: hidden; 
+        flex-direction: column; 
+        justify-content: center; 
+        align-items: flex-start; 
+        gap: 20px; 
+        display: inline-flex;
+      }
+
+      .storage-options-section {
+        justify-content: flex-start; 
+        align-items: center; 
+        gap: 20px; 
+        display: inline-flex;
+      }
+
+      .storage-type-options {
+        align-self: stretch; 
+        flex-direction: column; 
+        justify-content: flex-start; 
+        align-items: flex-start; 
+        gap: 40px; 
+        display: flex;
+      }
+
+      .storage-type-option-container {
+        width: 692px; 
+        overflow: hidden; 
+        justify-content: flex-start; 
+        align-items: flex-start; 
+        gap: 20px; 
+        display: inline-flex;
+      }
+
+      .storage-option-radio-button-container {
+        justify-content: flex-start; 
+        align-items: center; 
+        gap: 4px; 
+        display: flex;
+      }
+
+      .storage-option-radio-button {
+        width: 24px; 
+        height: 24px; 
+        position: relative; 
+        overflow: hidden;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/_wizard.scss
+++ b/app/assets/stylesheets/_wizard.scss
@@ -586,153 +586,153 @@
       }
 
       .form-field-label-vertical-container {
-        width: 183px; 
-        flex-direction: column; 
-        justify-content: flex-start; 
-        align-items: flex-start; 
+        width: 183px;
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: flex-start;
         display: inline-flex;
       }
 
       .form-field-label-vertical-text {
-        align-self: stretch; 
-        justify-content: center; 
-        display: flex; 
-        flex-direction: column; 
-        color: $black; 
-        font-size: 18px; 
-        font-family: $libre-franklin; 
-        font-weight: 600; 
-        line-height: 27px; 
+        align-self: stretch;
+        justify-content: center;
+        display: flex;
+        flex-direction: column;
+        color: $black;
+        font-size: 18px;
+        font-family: $libre-franklin;
+        font-weight: 600;
+        line-height: 27px;
         word-wrap: break-word;
       }
 
       .form-field-element-vertical-container {
         flex-direction: column;
-        justify-content: flex-start; 
-        align-items: flex-start; 
-        gap: 8px; 
+        justify-content: flex-start;
+        align-items: flex-start;
+        gap: 8px;
         display: inline-flex;
       }
 
       .estimated-files-dropdown {
-        align-self: stretch; 
-        flex-direction: column; 
-        justify-content: flex-start; 
-        align-items: flex-start; 
-        gap: 10px; 
+        align-self: stretch;
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: flex-start;
+        gap: 10px;
         display: flex;
       }
 
       .estimated-files-dropdown-subcontainer {
-        align-self: stretch; 
-        flex-direction: column; 
-        justify-content: flex-start; 
-        align-items: flex-start; 
-        gap: 4px; 
+        align-self: stretch;
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: flex-start;
+        gap: 4px;
         display: flex;
       }
 
       .estimated-files-inline-subcontainer {
-        align-self: stretch; 
-        padding-left: 12px; 
-        padding-right: 12px; 
-        padding-top: 8px; 
-        padding-bottom: 8px; 
-        background: var(--Neutral-White, white); 
-        border-radius: 8px; 
-        outline: 1px var(--Neutral-Medium-Gray, #D0D0D0) solid; 
-        outline-offset: -1px; 
-        justify-content: space-between; 
-        align-items: center; 
+        align-self: stretch;
+        padding-left: 12px;
+        padding-right: 12px;
+        padding-top: 8px;
+        padding-bottom: 8px;
+        background: var(--Neutral-White, white);
+        border-radius: 8px;
+        outline: 1px var(--Neutral-Medium-Gray, #d0d0d0) solid;
+        outline-offset: -1px;
+        justify-content: space-between;
+        align-items: center;
         display: inline-flex;
       }
 
       .storage-form-field-text {
-        color: $black; 
-        font-size: 16px; 
-        font-family: $libre-franklin; 
-        font-weight: 400; 
-        line-height: 24px; 
+        color: $black;
+        font-size: 16px;
+        font-family: $libre-franklin;
+        font-weight: 400;
+        line-height: 24px;
         word-wrap: break-word;
       }
 
       .storage-tooltip {
-        width: 100%; 
-        color: $gray-60; 
-        font-size: 14px; 
-        font-family: $libre-franklin; 
-        font-weight: 400; 
-        line-height: 21px; 
+        width: 100%;
+        color: $gray-60;
+        font-size: 14px;
+        font-family: $libre-franklin;
+        font-weight: 400;
+        line-height: 21px;
         word-wrap: break-word;
       }
 
       .connection-options-text-container {
-        flex: 1 1 0; 
-        overflow: hidden; 
-        flex-direction: column; 
-        justify-content: flex-start; 
-        align-items: flex-start; 
-        gap: 4px; 
+        flex: 1 1 0;
+        overflow: hidden;
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: flex-start;
+        gap: 4px;
         display: inline-flex;
       }
-      
+
       .connection-options-text {
-        justify-content: center; 
-        display: flex; 
-        flex-direction: column; 
-        color: var(--Neutral-Black, #121212); 
-        font-size: 16px; 
-        font-family: Libre Franklin; 
-        font-weight: 600; 
-        line-height: 24px; 
+        justify-content: center;
+        display: flex;
+        flex-direction: column;
+        color: var(--Neutral-Black, #121212);
+        font-size: 16px;
+        font-family: Libre Franklin;
+        font-weight: 600;
+        line-height: 24px;
         word-wrap: break-word;
       }
 
       .connection-options-radio-buttons-container {
-        overflow: hidden; 
-        flex-direction: column; 
-        justify-content: center; 
-        align-items: flex-start; 
-        gap: 20px; 
+        overflow: hidden;
+        flex-direction: column;
+        justify-content: center;
+        align-items: flex-start;
+        gap: 20px;
         display: inline-flex;
       }
 
       .storage-options-section {
-        justify-content: flex-start; 
-        align-items: center; 
-        gap: 20px; 
+        justify-content: flex-start;
+        align-items: center;
+        gap: 20px;
         display: inline-flex;
       }
 
       .storage-type-options {
-        align-self: stretch; 
-        flex-direction: column; 
-        justify-content: flex-start; 
-        align-items: flex-start; 
-        gap: 40px; 
+        align-self: stretch;
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: flex-start;
+        gap: 40px;
         display: flex;
       }
 
       .storage-type-option-container {
-        width: 692px; 
-        overflow: hidden; 
-        justify-content: flex-start; 
-        align-items: flex-start; 
-        gap: 20px; 
+        width: 692px;
+        overflow: hidden;
+        justify-content: flex-start;
+        align-items: flex-start;
+        gap: 20px;
         display: inline-flex;
       }
 
       .storage-option-radio-button-container {
-        justify-content: flex-start; 
-        align-items: center; 
-        gap: 4px; 
+        justify-content: flex-start;
+        align-items: center;
+        gap: 4px;
         display: flex;
       }
 
       .storage-option-radio-button {
-        width: 24px; 
-        height: 24px; 
-        position: relative; 
+        width: 24px;
+        height: 24px;
+        position: relative;
         overflow: hidden;
       }
     }

--- a/app/assets/stylesheets/_wizard.scss
+++ b/app/assets/stylesheets/_wizard.scss
@@ -306,7 +306,7 @@
             color: var(--Secondary-Red-Dark, #b00002);
 
             /* Body XXS */
-            font-family: "Libre Franklin";
+            font-family: $libre-franklin;
             font-size: 0.75rem;
             font-style: normal;
             font-weight: 400;
@@ -504,10 +504,10 @@
 
               .user-heading {
                 flex: 1 0 0;
-                color: var(--Neutral-Black, #121212);
+                color: $black;
 
                 /* Body S Bold */
-                font-family: "Libre Franklin";
+                font-family: $libre-franklin;
                 font-size: 1rem;
                 font-style: normal;
                 font-weight: 600;
@@ -520,7 +520,7 @@
             color: $gray-60;
 
             /* Body XS */
-            font-family: "Libre Franklin";
+            font-family: $libre-franklin;
             font-size: 0.875rem;
             font-style: normal;
             font-weight: 400;
@@ -586,7 +586,7 @@
       }
 
       .form-field-label-vertical-container {
-        width: 183px;
+        width: 11.438rem;
         flex-direction: column;
         justify-content: flex-start;
         align-items: flex-start;
@@ -599,10 +599,10 @@
         display: flex;
         flex-direction: column;
         color: $black;
-        font-size: 18px;
+        font-size: 1.125rem;
         font-family: $libre-franklin;
         font-weight: 600;
-        line-height: 27px;
+        line-height: 1.688rem;
         word-wrap: break-word;
       }
 
@@ -610,7 +610,7 @@
         flex-direction: column;
         justify-content: flex-start;
         align-items: flex-start;
-        gap: 8px;
+        gap: 0.5rem;
         display: inline-flex;
       }
 
@@ -619,7 +619,7 @@
         flex-direction: column;
         justify-content: flex-start;
         align-items: flex-start;
-        gap: 10px;
+        gap: 0.625rem;
         display: flex;
       }
 
@@ -628,19 +628,19 @@
         flex-direction: column;
         justify-content: flex-start;
         align-items: flex-start;
-        gap: 4px;
+        gap: 0.25rem;
         display: flex;
       }
 
       .estimated-files-inline-subcontainer {
         align-self: stretch;
-        padding-left: 12px;
-        padding-right: 12px;
-        padding-top: 8px;
-        padding-bottom: 8px;
-        background: var(--Neutral-White, white);
-        border-radius: 8px;
-        outline: 1px var(--Neutral-Medium-Gray, #d0d0d0) solid;
+        padding-left: 0.75rem;
+        padding-right: 0.75rem;
+        padding-top: 0.5rem;
+        padding-bottom: 0.5rem;
+        background: $white;
+        border-radius: 0.5rem;
+        outline: 1px $gray-20 solid;
         outline-offset: -1px;
         justify-content: space-between;
         align-items: center;
@@ -649,20 +649,20 @@
 
       .storage-form-field-text {
         color: $black;
-        font-size: 16px;
+        font-size: 1rem;
         font-family: $libre-franklin;
         font-weight: 400;
-        line-height: 24px;
+        line-height: 1.5rem;
         word-wrap: break-word;
       }
 
       .storage-tooltip {
         width: 100%;
         color: $gray-60;
-        font-size: 14px;
+        font-size: 0.875rem;
         font-family: $libre-franklin;
         font-weight: 400;
-        line-height: 21px;
+        line-height: 1.313rem;
         word-wrap: break-word;
       }
 
@@ -672,7 +672,7 @@
         flex-direction: column;
         justify-content: flex-start;
         align-items: flex-start;
-        gap: 4px;
+        gap: 0.25rem;
         display: inline-flex;
       }
 
@@ -680,11 +680,11 @@
         justify-content: center;
         display: flex;
         flex-direction: column;
-        color: var(--Neutral-Black, #121212);
-        font-size: 16px;
+        color: $black;
+        font-size: 1rem;
         font-family: Libre Franklin;
         font-weight: 600;
-        line-height: 24px;
+        line-height: 1.5rem;
         word-wrap: break-word;
       }
 
@@ -693,14 +693,14 @@
         flex-direction: column;
         justify-content: center;
         align-items: flex-start;
-        gap: 20px;
+        gap: 1.25rem;
         display: inline-flex;
       }
 
       .storage-options-section {
         justify-content: flex-start;
         align-items: center;
-        gap: 20px;
+        gap: 1.25rem;
         display: inline-flex;
       }
 
@@ -709,29 +709,29 @@
         flex-direction: column;
         justify-content: flex-start;
         align-items: flex-start;
-        gap: 40px;
+        gap: 2.5rem;
         display: flex;
       }
 
       .storage-type-option-container {
-        width: 692px;
+        width: 43.25rem;
         overflow: hidden;
         justify-content: flex-start;
         align-items: flex-start;
-        gap: 20px;
+        gap: 1.25rem;
         display: inline-flex;
       }
 
       .storage-option-radio-button-container {
         justify-content: flex-start;
         align-items: center;
-        gap: 4px;
+        gap: 0.25rem;
         display: flex;
       }
 
       .storage-option-radio-button {
-        width: 24px;
-        height: 24px;
+        width: 1.5rem;
+        height: 1.5rem;
         position: relative;
         overflow: hidden;
       }
@@ -775,7 +775,7 @@
       color: $black;
 
       /* Heading 4 */
-      font-family: "Libre Franklin";
+      font-family: $libre-franklin;
       font-size: 1.5rem;
       font-style: normal;
       font-weight: 600;
@@ -787,7 +787,7 @@
     color: $black;
 
     /* Body S */
-    font-family: "Libre Franklin";
+    font-family: $libre-franklin;
     font-size: 1rem;
     font-style: normal;
     font-weight: 400;

--- a/app/views/new_project_wizard/_form_project_storage.html.erb
+++ b/app/views/new_project_wizard/_form_project_storage.html.erb
@@ -62,59 +62,116 @@
   </div>
 </div>
 
+
 <div class="form-field">
-  <%= render partial: "/new_project_wizard/form_field_label",
-    locals: {field_label: "Estimated number of files", field_sub_label: ""} %>
-  <div>
-    <select name="request[number_of_files]" id="number_of_files">
-      <option <%= @request_model.number_of_files == "Less than 10,000" ? "selected" : "" %> >Less than 10,000</option>
-      <option <%= @request_model.number_of_files == "Between 10,000 and 100,000" ? "selected" : "" %> >Between 10,000 and 100,000</option>
-      <option <%= @request_model.number_of_files == "Between 100,000 and 1,000,000" ? "selected" : "" %> >Between 100,000 and 1,000,000</option>
-      <option <%= @request_model.number_of_files == "More than 1,000,000" ? "selected" : "" %> >More than 1,000,000</option>
-    </select>
-    <br/>
-    A rough estimate of the maximum file count for the project (this makes a difference for backend setup).
-  </div>
+    <div class="form-field-label-vertical-container">
+        <div class="form-field-label-vertical-text">Estimated Number of Files</div>
+    </div>
+    <div style="form-field-element-vertical-container">
+        <div class="estimated-files-dropdown">
+            <div data-label?="false" data-state="Default" class="estimated-files-dropdown-subcontainer">
+            <select name="request[number_of_files]" id="number_of_files" class="estimated-files-inline-subcontainer">
+              <option class="storage-form-field-text" <%= @request_model.number_of_files == "Less than 10,000" ? "selected" : "" %> >Less than 10,000</option>
+              <option class="storage-form-field-text"  <%= @request_model.number_of_files == "Between 10,000 and 100,000" ? "selected" : "" %> >Between 10,000 and 100,000</option>
+              <option class="storage-form-field-text" <%= @request_model.number_of_files == "Between 100,000 and 1,000,000" ? "selected" : "" %> >Between 100,000 and 1,000,000</option>
+              <option class="storage-form-field-text" <%= @request_model.number_of_files == "More than 1,000,000" ? "selected" : "" %> >More than 1,000,000</option>
+            </select>
+            </div>
+        </div>
+        <div class="storage-tooltip">A rough estimate of the maximum file count for the project (this makes a difference for backend setup).</div>
+    </div>
 </div>
 
 <div class="form-field">
-  <%= render partial: "/new_project_wizard/form_field_label",
+    <%= render partial: "/new_project_wizard/form_field_label",
     locals: {field_label: "Connection Options", field_sub_label: "Required"} %>
 
-    <div>
-      <p>Do you need to connect to High Performance Computing?</p>
-      <p>Select 'Yes' if you are a Princeton Research Computing user and you expect to need access to this project from select HPC clusters.</p>
-      <input type="radio" id="hpc_yes" name="request[hpc]" value="yes" <%= @request_model.hpc == "yes" ? "checked" : "" %> >
-      <label for="hpc_yes">Yes</label><br>
-      <input type="radio" id="hpc_no" name="request[hpc]" value="no" <%= @request_model.hpc == "no" ? "checked" : "" %> >
-      <label for="hpc_no">No</label><br>
-      <input type="radio" id="hpc_maybe" name="request[hpc]" value="maybe" <%= @request_model.hpc == "maybe" ? "checked" : "" %>>
-      <label for="hpc_maybe">Maybe</label>
-    </div>
-</div>
-
-<div class="form-field">
-    <div>
-      <p>Do you need a network file share?</p>
-      <p>Select 'Yes' if anyone on the project will need to connect a personal computer or lab workstation (via SMB/CIFS).</p>
-      <input type="radio" id="network_yes" name="request[smb]" value="yes" <%= @request_model.smb == "yes" ? "checked" : "" %> >
-      <label for="network_yes">Yes</label><br>
-      <input type="radio" id="network_no" name="request[smb]" value="no" <%= @request_model.smb == "no" ? "checked" : "" %> >
-      <label for="network_no">No</label><br>
-      <input type="radio" id="network_maybe" name="request[smb]" value="maybe" <%= @request_model.smb == "maybe" ? "checked" : "" %> >
-      <label for="network_maybe">Maybe</label>
-    </div>
-</div>
-
-<div class="form-field">
-    <div>
-      <p>Do you need to enable Globus transfers?</p>
-      <p>Select 'Yes' if the project will need its own Globus endpoint for high bandwidth data transfers.</p>
-      <input type="radio" id="globus_yes" name="request[globus]" value="yes" <%= @request_model.globus == "yes" ? "checked" : "" %> >
-      <label for="globus_yes">Yes</label><br>
-      <input type="radio" id="globus_no" name="request[globus]" value="no" <%= @request_model.globus == "no" ? "checked" : "" %> >
-      <label for="hpc_no">No</label><br>
-      <input type="radio" id="globus_maybe" name="request[globus]" value="maybe" <%= @request_model.globus == "maybe" ? "checked" : "" %> >
-      <label for="globus_maybe">Maybe</label>
+    <div style="flex: 1 1 0" class="form-field-element-vertical-container">
+        <div class="storage-type-options">
+            <div class="storage-type-option-container">
+                <div class="connection-options-text-container">
+                    <div class="connection-options-text">Do you need to connect to High Performance Computing?</div>
+                    <div style="align-self: stretch"><span class="storage-tooltip">Select 'Yes' if you are a Princeton Research Computing user and you expect to need access to this project from </span><span style="color: var(--Neutral-Dark-Gray, #717171); font-size: 14px; font-family: Libre Franklin; font-weight: 400; text-decoration: underline; line-height: 21px; word-wrap: break-word">select HPC clusters</span><span class="storage-tooltip">.</span></div>
+                </div>
+                <div data-selection="Default" class="connection-options-radio-buttons-container-container">
+                    <div class="storage-options-section">
+                        <div class="storage-option-radio-button-container">
+                            <label for="hpc_yes" class="storage-form-field-text">Yes</label>
+                            <div data-state="Default" class="storage-option-radio-button">
+                              <input type="radio" id="hpc_yes" name="request[hpc]" value="yes" <%= @request_model.hpc == "yes" ? "checked" : "" %> >
+                            </div>
+                        </div>
+                        <div class="storage-option-radio-button-container">
+                            <label for="hpc_no" class="storage-form-field-text">No</label>
+                            <div data-state="Default" class="storage-option-radio-button">
+                              <input type="radio" id="hpc_no" name="request[hpc]" value="no" <%= @request_model.hpc == "no" ? "checked" : "" %> >                            
+                            </div>
+                          </div>
+                        <div class="storage-option-radio-button-container">
+                            <label for="hpc_maybe" class="storage-form-field-text">Maybe</label>
+                            <div data-state="Default" class="storage-option-radio-button">
+                                <input type="radio" id="hpc_maybe" name="request[hpc]" value="maybe" <%= @request_model.hpc == "maybe" ? "checked" : "" %>>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="storage-type-option-container">
+                <div class="connection-options-text-container">
+                    <div class="connection-options-text">Do you need a network file share?</div>
+                    <div style="align-self: stretch;" class="storage-tooltip">Select 'Yes' if anyone on the project will need to connect a personal computer or lab workstation (via SMB/CIFS).</div>
+                </div>
+                <div data-selection="Default" class="connection-options-radio-buttons-container-container">
+                    <div class="storage-options-section">
+                        <div class="storage-option-radio-button-container">
+                            <label for="network_yes" class="storage-form-field-text">Yes</label>
+                            <div data-state="Default" class="storage-option-radio-button">
+                                <input type="radio" id="network_yes" name="request[smb]" value="yes" <%= @request_model.smb == "yes" ? "checked" : "" %> >
+                            </div>
+                        </div>
+                        <div class="storage-option-radio-button-container">
+                            <label for="network_no" class="storage-form-field-text">No</label>
+                            <div data-state="Default" class="storage-option-radio-button">
+                                <input type="radio" id="network_no" name="request[smb]" value="no" <%= @request_model.smb == "no" ? "checked" : "" %> >
+                            </div>
+                        </div>
+                        <div class="storage-option-radio-button-container">
+                            <label for="network_maybe" class="storage-form-field-text">Maybe</label>
+                            <div data-state="Default" class="storage-option-radio-button">
+                                <input type="radio" id="network_maybe" name="request[smb]" value="maybe" <%= @request_model.smb == "maybe" ? "checked" : "" %> >
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="storage-type-option-container">
+                <div class="connection-options-text-container">
+                    <div class="connection-options-text">Do you need to enable Globus transfers?</div>
+                    <div style="align-self: stretch"><span class="storage-tooltip">Select 'Yes' if the project will need its own </span><span style="color: var(--Neutral-Dark-Gray, #717171); font-size: 14px; font-family: Libre Franklin; font-weight: 400; text-decoration: underline; line-height: 21px; word-wrap: break-word">Globus</span><span class="storage-tooltip"> endpoint for high bandwidth data transfers.</span></div>
+                </div>
+                <div data-selection="Default" class="connection-options-radio-buttons-container-container">
+                    <div class="storage-options-section">
+                        <div class="storage-option-radio-button-container">
+                            <label for="globus_yes" class="storage-form-field-text">Yes</label>
+                            <div data-state="Default" class="storage-option-radio-button">
+                              <input type="radio" id="globus_yes" name="request[globus]" value="yes" <%= @request_model.globus == "yes" ? "checked" : "" %> >
+                            </div>
+                        </div>
+                        <div class="storage-option-radio-button-container">
+                            <label for="globus_no" class="storage-form-field-text">No</label>
+                            <div data-state="Default" class="storage-option-radio-button">
+                              <input type="radio" id="globus_no" name="request[globus]" value="no" <%= @request_model.globus == "no" ? "checked" : "" %> >
+                            </div>
+                        </div>
+                        <div class="storage-option-radio-button-container">
+                            <label for="globus_maybe" class="storage-form-field-text">Maybe</label>
+                            <div data-state="Default" class="storage-option-radio-button">
+                              <input type="radio" id="globus_maybe" name="request[globus]" value="maybe" <%= @request_model.globus == "maybe" ? "checked" : "" %> >
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </div>

--- a/app/views/new_project_wizard/_sidebar.html.erb
+++ b/app/views/new_project_wizard/_sidebar.html.erb
@@ -5,7 +5,7 @@
             <%= render partial: '/new_project_wizard/sidebar_multi_step', locals: { indicator_class: controller.controller_name.start_with?('project_information') ? '-current' : '-completed', 
                                                                                     step_number: 1, step_url: new_project_project_info_path(@request_model), step_name: 'Project Information'} %>
             <div data-count="3" class="substeps-container">
-                <div class="connector-line"></div>
+                <!-- <div class="connector-line"></div> -->
                 <%= render partial: '/new_project_wizard/sidebar_sub_step', locals: { indicator_class: controller.controller_name == 'project_information' ? '-current' : '-completed', 
                                                                                       text_class: controller.controller_name == 'project_information' ? '' : '-current', 
                                                                                       step_url: new_project_project_info_path(@request_model), step_name: 'Basic Details'} %>


### PR DESCRIPTION
Closes #1896 

## Screenshot

<img width="1242" height="574" alt="Screenshot 2025-09-24 at 4 36 58 PM" src="https://github.com/user-attachments/assets/c6a3ec9a-7e0b-4c0b-82cb-c759468f0f8c" />


I also commented out the little connector line for "Basic Details" since it looks odd given that we don't have other subsections yet:

## Screenshots

<img width="655" height="488" alt="Screenshot 2025-09-24 at 4 36 45 PM" src="https://github.com/user-attachments/assets/972823bd-c739-4fe1-9d7c-8795d5e0e41a" />

<img width="701" height="574" alt="Screenshot 2025-09-24 at 4 39 19 PM" src="https://github.com/user-attachments/assets/fbd3f41c-1ea0-4999-8bfd-da6c70f8b085" />

