### PR TITLE
Removing Project.approve!, since approved projects are created from an approved Request

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -32,21 +32,6 @@ class Project < ApplicationRecord
     end
   end
 
-  # TODO: Remove this method https://github.com/pulibrary/tigerdata-app/issues/1707 has been completed
-  def approve!(current_user:)
-    # This code is duplicated with Request.approve() and it should
-    # be removed. We keep it for now since we have way too many tests
-    # wired to it already. The goal is that projects won't be approved,
-    # instead Request are approved (and that process creates the project)
-    create_project_operation = ProjectCreate.new
-    result = create_project_operation.call(request: nil, approver: current_user, project: self)
-    if result.success?
-      self.mediaflux_id
-    else
-      raise ProjectCreate::ProjectCreateError, result.failure
-    end
-  end
-
   def activate(current_user:)
     raise StandardError.new("Only approved projects can be activated") if self.status != Project::APPROVED_STATUS
     metadata_request = Mediaflux::AssetMetadataRequest.new(session_token: current_user.mediaflux_session, id: self.mediaflux_id)
@@ -58,12 +43,6 @@ class Project < ApplicationRecord
     else
       raise StandardError.new("Title mismatch: #{title} != #{metadata_request.title}")
     end
-  end
-
-  def reload
-    super
-    @metadata_model = ProjectMetadata.new_from_hash(self.metadata)
-    self
   end
 
   def draft_doi(user: nil)
@@ -103,11 +82,6 @@ class Project < ApplicationRecord
 
   def project_directory
     metadata_model.project_directory || ""
-  end
-
-  def project_directory_parent_path
-    # The tigerdata.project.create expectes every project to be under "tigerdata"
-    Mediaflux::Connection.root
   end
 
   def project_directory_short

--- a/app/services/test_project_generator.rb
+++ b/app/services/test_project_generator.rb
@@ -48,10 +48,6 @@ class TestProjectGenerator
     end
     # rubocop:enable Metrics/MethodLength
 
-    def sponsor
-      User.where(uid: "tigerdatatester").first
-    end
-
     def departments
       ldepartments = []
       ldepartments << Affiliation.all[3] if (number % 7) == 0
@@ -59,13 +55,5 @@ class TestProjectGenerator
       ldepartments << Affiliation.all[1] if (number % 5) == 0
       ldepartments << Affiliation.all[0] if ldepartments.count == 0
       ldepartments
-    end
-
-    def project_id
-      part1 = rand(1...99).to_s.rjust(2, "0")
-      part2 = rand(1...99_999).to_s.rjust(5, "0")
-      part3 = rand(1...9999).to_s.rjust(4, "0")
-      part4 = rand(1...9999).to_s.rjust(4, "0")
-      "#{part1}.#{part2}/#{part3}-#{part4}"
     end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -244,42 +244,6 @@ RSpec.describe Project, type: :model, connect_to_mediaflux: true do
     end
   end
 
-  describe "#approve!" do
-    let(:datacite_stub) { instance_double(PULDatacite, draft_doi: "aaabbb123") }
-    let(:current_user) { FactoryBot.create(:user, mediaflux_session: SystemUser.mediaflux_session) }
-    let!(:project) do
-      request = FactoryBot.create(:request_project)
-      request.approve(current_user)
-    end
-
-    before do
-      allow(PULDatacite).to receive(:new).and_return(datacite_stub)
-    end
-
-    it "Records the mediaflux id and sets the status to approved",
-    :integration do
-      expect(project.mediaflux_id).not_to be_nil
-      expect(project.metadata_model.status).to eq Project::ACTIVE_STATUS
-    end
-
-    it "creates the provenance events when creating a new project",
-    :integration do
-      expect(project.mediaflux_id).not_to be_nil
-      expect(project.metadata_model.status).to eq Project::ACTIVE_STATUS
-
-      expect(project.provenance_events.count).to eq 3
-      approval_event = project.provenance_events.find { |event| event.event_type == ProvenanceEvent::APPROVAL_EVENT_TYPE }
-
-      expect(approval_event.event_type).to eq ProvenanceEvent::APPROVAL_EVENT_TYPE
-      expect(approval_event.event_person).to eq current_user.uid
-      expect(approval_event.event_details).to eq "Approved by #{current_user.display_name_safe}"
-
-      debug_event = project.provenance_events.find { |event| event.event_type == ProvenanceEvent::DEBUG_OUTPUT_TYPE }
-      expect(debug_event.event_person).to eq current_user.uid
-      expect(debug_event.event_details).to eq "Debug output"
-    end
-  end
-
   describe ".default_storage_unit" do
     it "returns the default storage unit of KB" do
       expect(described_class.default_storage_unit).to eq("KB")


### PR DESCRIPTION
Make sure the create operation has more test coverage

fixes #1707