### PR TITLE
The orange tester-trainer banner now appears above the black "TigerData" website header and below the blue "welcome to TigerData!" banner.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,8 +6,9 @@
   <body class="d-flex flex-column min-vh-100">
     <%= render partial: 'shared/alternate_mediaflux' %>
     <%= render partial: 'shared/banner' %>
-    <%= render partial: 'shared/header' %>
     <%= render partial: 'shared/emulator' %>
+    <%= render partial: 'shared/header' %>
+    
 
 
 <div class="container-fluid">

--- a/app/views/layouts/edit_request.html.erb
+++ b/app/views/layouts/edit_request.html.erb
@@ -5,8 +5,8 @@
   <body class="wizard-screen">
     <%= render partial: 'shared/alternate_mediaflux' %>
     <%= render partial: 'shared/banner' %>
-    <%= render partial: 'shared/header' %>
     <%= render partial: 'shared/emulator' %>
+    <%= render partial: 'shared/header' %>
     <%= render partial: 'shared/alert' %>
 
     <div class="wizard">

--- a/app/views/layouts/welcome.html.erb
+++ b/app/views/layouts/welcome.html.erb
@@ -5,8 +5,8 @@
   <body class="welcome-screen">
     <%= render partial: 'shared/alternate_mediaflux' %>
     <%= render partial: 'shared/banner' %>
-    <%= render partial: 'shared/header' %>
     <%= render partial: 'shared/emulator' %>
+    <%= render partial: 'shared/header' %>
     <%= render partial: 'shared/alert' %>
 
     <%= yield %>

--- a/app/views/layouts/wizard.html.erb
+++ b/app/views/layouts/wizard.html.erb
@@ -5,8 +5,8 @@
   <body class="wizard-screen">
     <%= render partial: 'shared/alternate_mediaflux' %>
     <%= render partial: 'shared/banner' %>
-    <%= render partial: 'shared/header' %>
     <%= render partial: 'shared/emulator' %>
+    <%= render partial: 'shared/header' %>
     <%= render partial: 'shared/alert' %>
 
     <div class="wizard">


### PR DESCRIPTION
Co-authored-by: Robert-Anthony Lee-Faison <leefaisonr@users.noreply.github.com>

ref #1961

<img width="1394" height="746" alt="Screenshot 2025-10-07 at 3 09 24 PM" src="https://github.com/user-attachments/assets/f61081cf-a5ad-43f8-8ac4-60850bf5428e" />
